### PR TITLE
Introduce IWebRequestStatsTracker

### DIFF
--- a/Core.Collectors/Collector/IWebRequestStatsTracker.cs
+++ b/Core.Collectors/Collector/IWebRequestStatsTracker.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.CloudMine.Core.Collectors.Collector
+{
+    /// <summary>
+    /// Abstracts the capability of tracking the number of successful and failed web requests such that an HttpClient can be used in a StatsTracker.
+    /// </summary>
+    public interface IWebRequestStatsTracker
+    {
+        int SuccessfulRequestCount { get; }
+        int FailedRequestCount { get; }
+    }
+}


### PR DESCRIPTION
This is one of the changes to bring StatsTracker from AzureDevOps collectos so that it can be also used with the GitHub collectors and becomes part of the core library.