### PR TITLE
Fix loop detection when the response for the second request is empty

### DIFF
--- a/Core.Collectors/Collector/CollectorBase.cs
+++ b/Core.Collectors/Collector/CollectorBase.cs
@@ -37,8 +37,8 @@ namespace Microsoft.CloudMine.Core.Collectors.Collector
             }
 
             this.enableLoopDetection = true;
-            this.previousRecordCount = 0;
-            this.previousRecordStrings = new List<string>();
+            this.previousRecordCount = -1;
+            this.previousRecordStrings = null;
         }
 
         public CollectorBase(IAuthentication authentication, ITelemetryClient telemetryClient, List<IRecordWriter> recordWriters, bool enableLoopDetection = true)


### PR DESCRIPTION
The loop detection ignores the very first response as an optimization (in case there is no batching, we don't want to waste computation power). However, this caused a bug when the second request of the batching yields to empty result since the default value of the previous response matches empty response.

This was a valid case for ADO collectors with the CommitChanges API. This change fixes this behavior by assigning the initial value of the previous response to something invalid so that the second response can never cause the loop detection to fail.