### PR TITLE
Fix loop detection bug when different API requests result with the same response

### DIFF
--- a/Core.Collectors/Collector/CollectorBase.cs
+++ b/Core.Collectors/Collector/CollectorBase.cs
@@ -78,9 +78,18 @@ namespace Microsoft.CloudMine.Core.Collectors.Collector
                     batchingHttpRequest.UpdateAvailability(serializedResponse.Response, recordCount);
 
                     // Check for looping. Majority of the requests won't have any batching at all, so start checking only after the very first call.
-                    if (this.enableLoopDetection && counter > 1 && this.DetectLooping(records))
+                    if (this.enableLoopDetection)
                     {
-                        throw new FatalTerminalException($"Terminating activity due to loop detection during batching. The following requests resulted with the same response: '{batchingHttpRequest.PreviousUrl}', '{batchingHttpRequest.CurrentUrl}'.");
+                        if (counter == 1)
+                        {
+                            // New batch, reset state for loop detection.
+                            this.previousRecordCount = -1;
+                            this.previousRecordStrings = null;
+                        }
+                        else if (this.DetectLooping(records))
+                        {
+                            throw new FatalTerminalException($"Terminating activity due to loop detection during batching. The following requests resulted with the same response: '{batchingHttpRequest.PreviousUrl}', '{batchingHttpRequest.CurrentUrl}'.");
+                        }
                     }
 
                     foreach (JObject record in records)

--- a/Core.Collectors/Collector/CollectorBase.cs
+++ b/Core.Collectors/Collector/CollectorBase.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Collector
                     {
                         if (counter == 1)
                         {
-                            // New batch, reset state for loop detection.
+                            // New request (batch), reset state for loop detection.
                             this.previousRecordCount = -1;
                             this.previousRecordStrings = null;
                         }


### PR DESCRIPTION
Loop detection state is not cleared between two different batching HTTP requests and therefore, there was a corner case, where if two different HTTP requests result with the exact response and they have multiple batches, this would be detected as a loop and the function would be terminated per loop detection logic. At high-level the following needs to happen to trigger this bug:
* a web request e.g., REQUEST1 has a response with multiple pages. Assume 2 pages and the second page content would be X
* Another web request REQUEST2 also has a response with 2 pages and the second page content would be X.

All in all, when we are evaluation loop detection for REQUEST2's second page, we would detect a loop (although none happened so far) and terminate the function.

This commit resets the state when a new request starts to ensure that this corner case is eliminated.