### PR TITLE
Add generic version of FunctionContextWriter.

### DIFF
--- a/Core.Collectors/Context/FunctionContextWriter.cs
+++ b/Core.Collectors/Context/FunctionContextWriter.cs
@@ -6,6 +6,21 @@ using System;
 
 namespace Microsoft.CloudMine.Core.Collectors.Context
 {
+    public class FunctionContextWriter<T> : ContextWriter<T> where T : FunctionContext
+    {
+        public override void AugmentMetadata(JObject metadata, T functionContext)
+        {
+            metadata.Add("FunctionStartDate", functionContext.FunctionStartDate);
+            metadata.Add("SessionId", functionContext.SessionId);
+            metadata.Add("CollectorType", functionContext.CollectorType.ToString());
+
+            if (functionContext.SliceDate != DateTime.MinValue)
+            {
+                metadata.Add("SliceDate", functionContext.SliceDate);
+            }
+        }
+    }
+
     public class FunctionContextWriter : ContextWriter<FunctionContext>
     {
         public override void AugmentMetadata(JObject metadata, FunctionContext functionContext)


### PR DESCRIPTION
So that GitHub WebhookProcessorContextWriter can properly extend this. Keeping the old one since the update will be compatibility-breaking for ADO and GitHub collectors (will be removed once those are changed first).