### PR TITLE
Remove non-generic FunctionContextWriter

### DIFF
--- a/Core.Collectors/Context/FunctionContextWriter.cs
+++ b/Core.Collectors/Context/FunctionContextWriter.cs
@@ -20,19 +20,4 @@ namespace Microsoft.CloudMine.Core.Collectors.Context
             }
         }
     }
-
-    public class FunctionContextWriter : ContextWriter<FunctionContext>
-    {
-        public override void AugmentMetadata(JObject metadata, FunctionContext functionContext)
-        {
-            metadata.Add("FunctionStartDate", functionContext.FunctionStartDate);
-            metadata.Add("SessionId", functionContext.SessionId);
-            metadata.Add("CollectorType", functionContext.CollectorType.ToString());
-
-            if (functionContext.SliceDate != DateTime.MinValue)
-            {
-                metadata.Add("SliceDate", functionContext.SliceDate);
-            }
-        }
-    }
 }


### PR DESCRIPTION
This is no longer needed. Just cleaning up.