### PR TITLE
Add ability to track and consume attempt index within the retry rule.

### DIFF
--- a/Core.Collectors/Web/RetryRule.cs
+++ b/Core.Collectors/Web/RetryRule.cs
@@ -11,5 +11,22 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
     {
         public Func<HttpResponseMessage, Task<bool>> ShallRetryAsync { get; set; } = respose => Task.FromResult(false);
         public TimeSpan[] DelayBeforeRetries { get; set; } = new TimeSpan[0];
+
+        public long AttemptIndex { get; private set; }
+
+        public RetryRule()
+        {
+            this.AttemptIndex = 0;
+        }
+
+        public void Clear()
+        {
+            this.AttemptIndex = 0;
+        }
+
+        public void Consume()
+        {
+            this.AttemptIndex++;
+        }
     }
 }


### PR DESCRIPTION
This is needed to make flakey web exception retries more efficient and intelligent. Especially when one type of exception (e.g., BadGateway) happens more frequently than the others.