### PR TITLE
Initialize record writer if WriteLineAsync is the first call.

### DIFF
--- a/Core.Collectors/IO/RecordWriterCore.cs
+++ b/Core.Collectors/IO/RecordWriterCore.cs
@@ -119,6 +119,11 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
 
         public async Task WriteLineAsync(string content)
         {
+            if (!this.initialized)
+            {
+                await this.InitializeAsync(outputSuffix: string.Empty).ConfigureAwait(false);
+            }
+
             this.SizeInBytes = this.currentWriter.BaseStream.Position;
 
             // Check if the current file needs to be rolled over.

--- a/Core.Collectors/IO/SplitAzureBlobRecordWriter.cs
+++ b/Core.Collectors/IO/SplitAzureBlobRecordWriter.cs
@@ -117,6 +117,11 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
                 RecordType = "None",
             };
 
+            if (!this.initialized)
+            {
+                await this.InitializeAsync(recordContext).ConfigureAwait(false);
+            }
+
             WriterState writerState = await this.GetOrAddWriterAsync(recordContext).ConfigureAwait(false);
             await writerState.WriteLineAsync(content).ConfigureAwait(false);
         }


### PR DESCRIPTION
This is already the behavior with WriteRecordAsync.