### PR TITLE
Fix File.Move(..) bug.

### DIFF
--- a/Core.Collectors/IO/AdlsBulkRecordWriter.cs
+++ b/Core.Collectors/IO/AdlsBulkRecordWriter.cs
@@ -71,6 +71,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             DateTime dateTimeSignature = DateTime.UtcNow + MaxUploadDelay;
             string fileName = $"{this.GetOutputPathPrefix(dateTimeSignature)}{this.currentSuffix}.json";
             string finalOutputPath = Path.Combine(this.localRoot, fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(finalOutputPath));
 
             // Rename local file.
             try


### PR DESCRIPTION
There is a good chance that the error was happening because some of the destination's parents were missing due to day overlap (with 10 minutes addition).