### PR TITLE
Move ApiDomain to global section of the config (CEDAR.GitHub.Collector Issue #36)

### DIFF
--- a/Core.Collectors.Tests/Config/ConfigManagerTests.cs
+++ b/Core.Collectors.Tests/Config/ConfigManagerTests.cs
@@ -9,10 +9,11 @@ namespace Microsoft.CloudMine.Core.Collectors.Tests.Config
     [TestClass]
     public class ConfigManagerTests
     {
-        [TestMethod]
-        public void GetDefaultAuthentication()
-        {
+        private ConfigManager configManager;
 
+        [TestInitialize]
+        public void Setup()
+        {
             string jsonInput = @"
             {
                 'Authentication' : {
@@ -22,11 +23,22 @@ namespace Microsoft.CloudMine.Core.Collectors.Tests.Config
                 },
                 'Collectors' : {
                     'Main' : {}   
-                }
+                },
+                'ApiDomain':  'api.github.com'
             }";
 
-            ConfigManager configManager = new ConfigManager(jsonInput);
-            Assert.IsNotNull(configManager.GetAuthentication("Main"));
+            this.configManager = new ConfigManager(jsonInput);
+        }
+            [TestMethod]
+        public void GetDefaultAuthentication()
+        {
+            Assert.IsNotNull(this.configManager.GetAuthentication("Main"));
+        }
+
+        [TestMethod]
+        public void GetApiDomain()
+        {
+            Assert.AreEqual("api.github.com", configManager.GetApiDomain());
         }
     }
 }

--- a/Core.Collectors/Config/ConfigManager.cs
+++ b/Core.Collectors/Config/ConfigManager.cs
@@ -168,7 +168,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Config
             }
             catch (Exception)
             {
-                throw new FatalTerminalException($"Invalid URI: The hostname could not be parsed for API domain {apiDomainToken}. The API domain must be provided in Settings.json under the github-settings Azure Blob.");
+                throw new FatalTerminalException($"Invalid URI: The hostname could not be parsed for API domain {apiDomainToken}. The API domain must be provided in Settings.json.");
             }
             return apiDomain;
         }


### PR DESCRIPTION
This commit moves the API domain from local.settings.json to Settings.json. To do so, I added two methods to the ConfigManager (GetApiDomainToken() and GetApiDomain()). In the setup of ConfigManager I created a map from the DefaultKey to the ApiDomainToken. I also increased coverage in ConfigManagerTests.

This pull request contains changes to files referenced in my pull request under the same name in CEDAR.GitHub.Collector.