### PR TITLE
Move apiDomainToken and GetApiDomain() from parent to child class

### DIFF
--- a/Core.Collectors.Tests/Config/ConfigManagerTests.cs
+++ b/Core.Collectors.Tests/Config/ConfigManagerTests.cs
@@ -9,10 +9,11 @@ namespace Microsoft.CloudMine.Core.Collectors.Tests.Config
     [TestClass]
     public class ConfigManagerTests
     {
-        [TestMethod]
-        public void GetDefaultAuthentication()
-        {
+        private ConfigManager configManager;
 
+        [TestInitialize]
+        public void Setup()
+        {
             string jsonInput = @"
             {
                 'Authentication' : {
@@ -22,11 +23,22 @@ namespace Microsoft.CloudMine.Core.Collectors.Tests.Config
                 },
                 'Collectors' : {
                     'Main' : {}   
-                }
+                },
+                'ApiDomain':  'api.github.com'
             }";
 
-            ConfigManager configManager = new ConfigManager(jsonInput);
-            Assert.IsNotNull(configManager.GetAuthentication("Main"));
+            this.configManager = new ConfigManager(jsonInput);
+        }
+            [TestMethod]
+        public void GetDefaultAuthentication()
+        {
+            Assert.IsNotNull(this.configManager.GetAuthentication("Main"));
+        }
+
+        [TestMethod]
+        public void GetApiDomain()
+        {
+            Assert.AreEqual("api.github.com", configManager.GetApiDomain());
         }
     }
 }

--- a/Core.Collectors.Tests/Config/ConfigManagerTests.cs
+++ b/Core.Collectors.Tests/Config/ConfigManagerTests.cs
@@ -29,16 +29,11 @@ namespace Microsoft.CloudMine.Core.Collectors.Tests.Config
 
             this.configManager = new ConfigManager(jsonInput);
         }
-            [TestMethod]
+
+        [TestMethod]
         public void GetDefaultAuthentication()
         {
             Assert.IsNotNull(this.configManager.GetAuthentication("Main"));
-        }
-
-        [TestMethod]
-        public void GetApiDomain()
-        {
-            Assert.AreEqual("api.github.com", configManager.GetApiDomain());
         }
     }
 }

--- a/Core.Collectors/Config/ConfigManager.cs
+++ b/Core.Collectors/Config/ConfigManager.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Config
 
         private TelemetryClient telemetryClient;
         private readonly Dictionary<string, Dictionary<string, string>> telemetryEvents;
-        private readonly JObject config;
+        protected readonly JObject config;
         private readonly JToken apiDomainToken;
         private readonly Dictionary<string, JToken> authenticationTokenMap;
         private readonly Dictionary<string, JArray> recordWriterTokensMap;
@@ -40,7 +40,6 @@ namespace Microsoft.CloudMine.Core.Collectors.Config
             }
 
             this.config = JObject.Parse(jsonString);
-            this.apiDomainToken = config.SelectToken("ApiDomain");
             JToken defaultAuth = config.SelectToken("Authentication");
             this.authenticationTokenMap.Add(DefaultKey, defaultAuth);
             try
@@ -95,7 +94,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Config
             return this.config.SelectToken(jsonPath);
         }
 
-        private void ValidateSettingsExist()
+        protected void ValidateSettingsExist()
         {
             if (!this.settingsFound)
             {
@@ -156,21 +155,6 @@ namespace Microsoft.CloudMine.Core.Collectors.Config
                 authenticationToken = this.authenticationTokenMap[DefaultKey];
             }
             return authenticationToken;
-        }
-
-        public string GetApiDomain()
-        {
-            ValidateSettingsExist();
-            string apiDomain = string.Empty;
-            try
-            {
-                apiDomain = this.apiDomainToken.Value<string>();
-            }
-            catch (Exception)
-            {
-                throw new FatalTerminalException($"Invalid URI: The hostname could not be parsed for API domain {apiDomainToken}. The API domain must be provided in Settings.json.");
-            }
-            return apiDomain;
         }
 
         public StorageManager GetStorageManager(string collectorType, ITelemetryClient telemetryClient)

--- a/Core.Collectors/Config/ConfigManager.cs
+++ b/Core.Collectors/Config/ConfigManager.cs
@@ -168,7 +168,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Config
             }
             catch (Exception)
             {
-                throw new FatalTerminalException($"Invalid URI: The hostname could not be parsed for API domain {apiDomainToken}. The API domain must be provided in Settings.json under the github-settings Azure Blob.");
+                throw new FatalTerminalException($"Invalid URI: The hostname could not be parsed for API domain {apiDomainToken}. The API domain must be provided in Settings.json.");
             }
             return apiDomain;
         }


### PR DESCRIPTION
Currently, apiDomainToken and GetApiDomain() are in ConfigManager. This logic is only relevant to GithubConfigManager, so I moved the code pertaining the API domain out of this class. To access certain variables/methods in the child class I changed them to protected.