### PR TITLE
Add capability to have dictionary-based configs in the mock config value resolver

### DIFF
--- a/Core.Collectors.Tests/Config/MockConfigValueResolver.cs
+++ b/Core.Collectors.Tests/Config/MockConfigValueResolver.cs
@@ -2,21 +2,36 @@
 // Licensed under the MIT License.
 
 using Microsoft.CloudMine.Core.Collectors.Config;
+using System;
+using System.Collections.Generic;
 
 namespace Microsoft.CloudMine.Core.Collectors.Tests.Config
 {
     public class MockConfigValueResolver : IConfigValueResolver
     {
-        private readonly string configValue;
+        private readonly Dictionary<string, string> configMap;
 
         public MockConfigValueResolver(string configValue)
         {
-            this.configValue = configValue;
+            this.configMap = new Dictionary<string, string>()
+            {
+                { "ConfigValue", configValue },
+            };
+        }
+
+        public MockConfigValueResolver(Dictionary<string, string> configMap)
+        {
+            this.configMap = configMap;
         }
 
         public string ResolveConfigValue(string configIdentifier)
         {
-            return this.configValue;
+            if (!this.configMap.TryGetValue(configIdentifier, out string result))
+            {
+                throw new InvalidOperationException($"MockConfigValueResolver does not have a value for '{configIdentifier}'.");
+            }
+
+            return result;
         }
     }
 }

--- a/Core.Collectors.Tests/Config/MockConfigValueResolver.cs
+++ b/Core.Collectors.Tests/Config/MockConfigValueResolver.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Tests.Config
         {
             this.configMap = new Dictionary<string, string>()
             {
-                { "ConfigValue", configValue },
+                { "PersonalAccessToken", configValue },
             };
         }
 


### PR DESCRIPTION
This is needed for some changes on the ADO side.