### PR TITLE
Move ADLS ingestion app details from local to global settings

### DIFF
--- a/Core.Collectors/Utility/JTokenUtility.cs
+++ b/Core.Collectors/Utility/JTokenUtility.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.CloudMine.Core.Collectors.Utility
+{
+    public static class JTokenUtility
+    {
+        private static bool IsNull(JToken token)
+        {
+            return token == null;
+        }
+
+        private static bool IsEmpty(JToken token)
+        {
+            return IsNull(token) ||
+                   (token.Type == JTokenType.Array && !token.HasValues) ||
+                   (token.Type == JTokenType.Object && !token.HasValues) ||
+                   (token.Type == JTokenType.String && token.ToString() == string.Empty);
+        }
+
+        private static bool IsWhiteSpace(JToken token)
+        {
+            return token.Value<string>().All(char.IsWhiteSpace);
+        }
+
+        // This method is functionally the same as string.IsNullOrEmpty(), but it works with a JToken contains any type. 
+        // This reduces the number of checks you need to make from 4 to 1 if you want to determine if the value of a JToken containing an unknown type is null or empty.
+        public static bool IsNullOrEmpty(JToken token)
+        {
+            return IsNull(token) || IsEmpty(token);
+        }
+
+        // This method is functionally the same as string.IsNullOrWhiteSpace(), but it works with a JToken that contains any type.
+        // This reduces the number of checks you need to make from 5 to 1 if you want to determine if the value of a JToken containing an unknown type is null, empty, or whitespace.
+        public static bool IsNullOrWhiteSpace(JToken token)
+        {
+            return IsNull(token) || IsEmpty(token) || IsWhiteSpace(token);
+        }
+    }
+}

--- a/Core.Collectors/Utility/JTokenUtility.cs
+++ b/Core.Collectors/Utility/JTokenUtility.cs
@@ -15,8 +15,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Utility
 
         private static bool IsEmpty(JToken token)
         {
-            return IsNull(token) ||
-                   (token.Type == JTokenType.Array && !token.HasValues) ||
+            return (token.Type == JTokenType.Array && !token.HasValues) ||
                    (token.Type == JTokenType.Object && !token.HasValues) ||
                    (token.Type == JTokenType.String && token.ToString() == string.Empty);
         }

--- a/Core.Collectors/Utility/JTokenUtility.cs
+++ b/Core.Collectors/Utility/JTokenUtility.cs
@@ -27,14 +27,14 @@ namespace Microsoft.CloudMine.Core.Collectors.Utility
 
         // This method is functionally the same as string.IsNullOrEmpty(), but it works with a JToken contains any type. 
         // This reduces the number of checks you need to make from 4 to 1 if you want to determine if the value of a JToken containing an unknown type is null or empty.
-        public static bool IsNullOrEmpty(JToken token)
+        public static bool IsNullOrEmpty(this JToken token)
         {
             return IsNull(token) || IsEmpty(token);
         }
 
         // This method is functionally the same as string.IsNullOrWhiteSpace(), but it works with a JToken that contains any type.
         // This reduces the number of checks you need to make from 5 to 1 if you want to determine if the value of a JToken containing an unknown type is null, empty, or whitespace.
-        public static bool IsNullOrWhiteSpace(JToken token)
+        public static bool IsNullOrWhiteSpace(this JToken token)
         {
             return IsNull(token) || IsEmpty(token) || IsWhiteSpace(token);
         }

--- a/Core.Collectors/Web/AdlsClientWrapper.cs
+++ b/Core.Collectors/Web/AdlsClientWrapper.cs
@@ -24,6 +24,11 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
 
         public AdlsClient AdlsClient { get; private set; }
 
+        public AdlsClientWrapper()
+        {
+
+        }
+
         public AdlsClientWrapper(string settings)
         {
             JObject config = JObject.Parse(settings);

--- a/Core.Collectors/Web/AdlsClientWrapper.cs
+++ b/Core.Collectors/Web/AdlsClientWrapper.cs
@@ -8,6 +8,7 @@ using Microsoft.Rest;
 using Microsoft.Rest.Azure.Authentication;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.CloudMine.Core.Collectors.Web
 {
@@ -24,6 +25,8 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
 
         public AdlsClient AdlsClient { get; private set; }
 
+        // This is the old AdlsClientWrapper API.
+        // The old API will be deprecated soon, but to protect our jobs from failing, we need to support both the old API and new API.
         public AdlsClientWrapper()
         {
             string clientId = Environment.GetEnvironmentVariable("AdlsIngestionApplicationId");
@@ -47,6 +50,15 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
 
         public AdlsClientWrapper(string settings)
         {
+            if (settings == null)
+            {
+                // When the global settings string is null, we are using the old AdlsClientWrapper API.
+                // The old API had to be moved from a constructor to a private method because the Azure Function magic in builder services is sometimes calling the new API
+                // even with an old version of CEDAR/GitHub and ADO (this is probably due to having a preference for the constructor with a parameter).
+                this.InvokeOldAdlsClientWrapperApi();
+                return;
+            }
+
             JObject config = JObject.Parse(settings);
             JToken clientIdToken = config.SelectToken("AdlsIngestionApplicationId");
             JToken secretKeyEnvironmentVariableToken = config.SelectToken("AdlsIngestionApplicationSecretEnvironmentVariable");
@@ -63,6 +75,27 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
             if (string.IsNullOrWhiteSpace(secretKey))
             {
                 throw new FatalTerminalException($"For token '{secretKeyEnvironmentVariableToken}', local.settings.json must provide an ADLS secret key.");
+            }
+
+            ActiveDirectoryServiceSettings serviceSettings = ActiveDirectoryServiceSettings.Azure;
+            serviceSettings.TokenAudience = AdlTokenAudience;
+            ServiceClientCredentials adlCreds = ApplicationTokenProvider.LoginSilentAsync(TenantId, clientId, secretKey, serviceSettings).GetAwaiter().GetResult();
+
+            // Marcel: ProcCount * 8 is usually the recommended number of threads to be used without deprecation of performance to to overscheduling and preemption. It supposed to account for usage and IO completion waits.
+            this.AdlsClient = AdlsClient.CreateClient(AdlsAccount, adlCreds, Environment.ProcessorCount * 8);
+        }
+
+        private void InvokeOldAdlsClientWrapperApi()
+        {
+            string clientId = Environment.GetEnvironmentVariable("AdlsIngestionApplicationId");
+            string secretKey = Environment.GetEnvironmentVariable("AdlsIngestionApplicationSecret");
+
+            if (string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(secretKey))
+            {
+                // Don't fail loading the function app environment if these variables are not provided. Instead don't initialize the ADLS client.
+                // This way, we permit functions that don't depend on the ADLS client to still run without configuring the ADLS client.
+                // Once the function loads, we will also log the fact that ADLS client is not initialized separately.
+                return;
             }
 
             ActiveDirectoryServiceSettings serviceSettings = ActiveDirectoryServiceSettings.Azure;

--- a/Core.Collectors/Web/AdlsClientWrapper.cs
+++ b/Core.Collectors/Web/AdlsClientWrapper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
             JObject config = JObject.Parse(settings);
             JToken clientIdToken = config.SelectToken("AdlsIngestionApplicationId");
             JToken secretKeyEnvironmentVariableToken = config.SelectToken("AdlsIngestionApplicationSecretEnvironmentVariable");
-            if (JTokenUtility.IsNullOrWhiteSpace(clientIdToken) || JTokenUtility.IsNullOrWhiteSpace(secretKeyEnvironmentVariableToken))
+            if (clientIdToken.IsNullOrWhiteSpace() || secretKeyEnvironmentVariableToken.IsNullOrWhiteSpace())
             {
                 // Don't fail loading the function app environment if these variables are not provided. Instead don't initialize the ADLS client.
                 // This way, we permit functions that don't depend on the ADLS client to still run without configuring the ADLS client.

--- a/Core.Collectors/Web/AdlsClientWrapper.cs
+++ b/Core.Collectors/Web/AdlsClientWrapper.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT License.
 
 using Microsoft.Azure.DataLake.Store;
+using Microsoft.CloudMine.Core.Collectors.Error;
+using Microsoft.CloudMine.Core.Collectors.Utility;
 using Microsoft.Rest;
 using Microsoft.Rest.Azure.Authentication;
+using Newtonsoft.Json.Linq;
 using System;
 
 namespace Microsoft.CloudMine.Core.Collectors.Web
@@ -21,17 +24,24 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
 
         public AdlsClient AdlsClient { get; private set; }
 
-        public AdlsClientWrapper()
+        public AdlsClientWrapper(string settings)
         {
-            string clientId = Environment.GetEnvironmentVariable("AdlsIngestionApplicationId");
-            string secretKey = Environment.GetEnvironmentVariable("AdlsIngestionApplicationSecret");
-
-            if (string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(secretKey))
+            JObject config = JObject.Parse(settings);
+            JToken clientIdToken = config.SelectToken("AdlsIngestionApplicationId");
+            JToken secretKeyEnvironmentVariableToken = config.SelectToken("AdlsIngestionApplicationSecretEnvironmentVariable");
+            if (JTokenUtility.IsNullOrWhiteSpace(clientIdToken) || JTokenUtility.IsNullOrWhiteSpace(secretKeyEnvironmentVariableToken))
             {
                 // Don't fail loading the function app environment if these variables are not provided. Instead don't initialize the ADLS client.
                 // This way, we permit functions that don't depend on the ADLS client to still run without configuring the ADLS client.
                 // Once the function loads, we will also log the fact that ADLS client is not initialized separately.
                 return;
+            }
+
+            string clientId = clientIdToken.Value<string>();
+            string secretKey = Environment.GetEnvironmentVariable(secretKeyEnvironmentVariableToken.Value<string>());
+            if (string.IsNullOrWhiteSpace(secretKey))
+            {
+                throw new FatalTerminalException($"For token '{secretKeyEnvironmentVariableToken}', local.settings.json must provide an ADLS secret key.");
             }
 
             ActiveDirectoryServiceSettings serviceSettings = ActiveDirectoryServiceSettings.Azure;


### PR DESCRIPTION
This PR moves the ADLS ingestion application details from local.settings.json to Settings.json. 

To do this, I pass the global settings JSON string to AdlsClientWrapper and parse it for two new keys `AdlsIngestionApplicationId` and `AdlsIngestionApplicationSecretEnvironmentVariable`. The former is moved directly from local settings, the latter contains the environment variable name of the ADLS secret. The global settings string is accessed from builder services (changes in `ServiceStartup.Configure()` in CEDAR/GitHub and ADO will be made to add the string to builder services).

I also added a utility class `JTokenUtility` that allows me to perform checks on JTokens just like `string.IsNullOrEmpty()` and `string.IsNullOrWhiteSpace()`. This is great because it cleans up the checks in AdlsClientWrapper() (number of checks needed reduced from 4 -> 2) and will allow me to clean up other code in the collectors in future PRs.