### PR TITLE
Reduce logging

### DIFF
--- a/Core.Collectors/IO/RecordWriterCore.cs
+++ b/Core.Collectors/IO/RecordWriterCore.cs
@@ -241,7 +241,6 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
         {
             if (!this.initialized)
             {
-                TelemetryClient.LogWarning("RecordWriter.Dispose was called before RecordWriter was initialized. Ignoring the call.");
                 return;
             }
 

--- a/Core.Collectors/IO/SplitAzureBlobRecordWriter.cs
+++ b/Core.Collectors/IO/SplitAzureBlobRecordWriter.cs
@@ -219,7 +219,6 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
         {
             if (!this.initialized)
             {
-                TelemetryClient.LogWarning("RecordWriter.Dispose was called before RecordWriter was initialized. Ignoring the call.");
                 return;
             }
 


### PR DESCRIPTION
These two lines are causing approx. 0.4M trace events per day. They happen so frequently and are valid when e.g., there is no data generated during collection that there is no gain from logging them. Removing to save some cost.