### PR TITLE
CachedCloudQueues

### DIFF
--- a/Core.Collectors/IO/AzureHelpers.cs
+++ b/Core.Collectors/IO/AzureHelpers.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             }
         }
 
-        public static async Task<CloudQueue> GetStorageQueueAsync(string queueName, string storageConnectionEnvironmentVariable)
+        public static async Task<CloudQueue> GetStorageQueueAsync(string queueName, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
         {
             CloudStorageAccount storageAccount = GetStorageAccount(storageConnectionEnvironmentVariable);
             CloudQueueClient queueClient = storageAccount.CreateCloudQueueClient();

--- a/Core.Collectors/IO/SplitAzureBlobRecordWriter.cs
+++ b/Core.Collectors/IO/SplitAzureBlobRecordWriter.cs
@@ -321,7 +321,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
                         // Azure queue names are limited with 63 characters. Use only the first 63 characters.
                         queueName = queueName.Substring(0, 63);
                     }
-                    CloudQueue queue = await AzureHelpers.GetStorageQueueAsync(queueName, this.storageConnectionEnvironmentVariable).ConfigureAwait(false);
+                    CloudQueue queue = await AzureHelpers.GetStorageQueueCachedAsync(queueName, this.storageConnectionEnvironmentVariable).ConfigureAwait(false);
                     this.notificationQueue = new CloudQueueWrapper(queue);
                 }
 


### PR DESCRIPTION
Add ability to cached cloud queue initializations in AzureHelpers. This is especially important to optimize queue client instantiations for AzureSplitBlobWriter