### PR TITLE
Fix ADLS Bulk Record Writer

### DIFF
--- a/Core.Collectors/IO/AdlsBulkRecordWriter.cs
+++ b/Core.Collectors/IO/AdlsBulkRecordWriter.cs
@@ -162,8 +162,10 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             return Task.CompletedTask;
         }
 
-        protected override void DisposeInternal()
+        public override async Task FinalizeAsync()
         {
+            await base.FinalizeAsync().ConfigureAwait(false);
+
             try
             {
                 Directory.Delete(this.localRoot, true);

--- a/Core.Collectors/IO/RecordWriterCore.cs
+++ b/Core.Collectors/IO/RecordWriterCore.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             // Default implementation does not do anything.
         }
 
-        public async Task FinalizeAsync()
+        public virtual async Task FinalizeAsync()
         {
             if (!this.initialized)
             {
@@ -245,13 +245,6 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             }
 
             this.currentWriter.Dispose();
-
-            this.DisposeInternal();
-        }
-
-        protected virtual void DisposeInternal()
-        {
-            // Default implementation does nothing.
         }
 
         private void AugmentRecordMetadata(JObject record, RecordContext recordContext)


### PR DESCRIPTION
DisposeInternal does not work since the latest upload happens after dispose (after the file is closed). Therefore, move the logic to delete local root to FinalizeAsync(..) which is where the last upload is happening.