### PR TITLE
[Data Lake] Migrate Storage DataLake to Track2

### DIFF
--- a/Core.Collectors.Tests/Core.Collectors.Tests.csproj
+++ b/Core.Collectors.Tests/Core.Collectors.Tests.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />

--- a/Core.Collectors/Config/StorageManager.cs
+++ b/Core.Collectors/Config/StorageManager.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Azure.DataLake.Store;
+using Azure.Storage.Files.DataLake;
 using Microsoft.CloudMine.Core.Collectors.Context;
 using Microsoft.CloudMine.Core.Collectors.Error;
 using Microsoft.CloudMine.Core.Collectors.IO;
@@ -28,7 +28,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Config
             this.initialized = false;
         }
 
-        public List<IRecordWriter> InitializeRecordWriters<T>(string identifier, T functionContext, ContextWriter<T> contextWriter, AdlsClient adlsClient) where T : FunctionContext
+        public List<IRecordWriter> InitializeRecordWriters<T>(string identifier, T functionContext, ContextWriter<T> contextWriter, DataLakeServiceClient dataLakeServiceClient) where T : FunctionContext
         {
             if (this.initialized)
             {
@@ -49,7 +49,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Config
                 switch (recordWriterType)
                 {
                     case RecordWriterType.AzureDataLakeStorageV1:
-                        IRecordWriter adlsRecordWriter = this.InitializeAdlsBulkRecordWriter(recordWriterToken, adlsClient, identifier, functionContext, contextWriter);
+                        IRecordWriter adlsRecordWriter = this.InitializeAdlsBulkRecordWriter(recordWriterToken, dataLakeServiceClient, identifier, functionContext, contextWriter);
                         this.recordWriters.Add(adlsRecordWriter);
                         break;
                     case RecordWriterType.AzureBlob:
@@ -110,7 +110,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Config
             return this.ConstructAzureBlobWriter(rootContainer, outputQueueName, identifier, this.telemetryClient, functionContext, contextWriter, storageConnectionEnvironmentVariable, notificationQueueEnvironmentVariable);
         }
 
-        private IRecordWriter InitializeAdlsBulkRecordWriter<T>(JToken recordWriterToken, AdlsClient adlsClient, string identifier, T functionContext, ContextWriter<T> contextWriter) where T : FunctionContext
+        private IRecordWriter InitializeAdlsBulkRecordWriter<T>(JToken recordWriterToken, DataLakeServiceClient dataLakeServiceClient, string identifier, T functionContext, ContextWriter<T> contextWriter) where T : FunctionContext
         {
             JToken rootFolderToken = recordWriterToken.SelectToken("RootFolder");
             JToken versionToken = recordWriterToken.SelectToken("Version");
@@ -121,7 +121,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Config
 
             string rootFolder = rootFolderToken.Value<string>();
             string version = versionToken.Value<string>();
-            return new AdlsBulkRecordWriter<T>(adlsClient, identifier, this.telemetryClient, functionContext, contextWriter, root: rootFolder, version);
+            return new AdlsBulkRecordWriter<T>(dataLakeServiceClient, identifier, this.telemetryClient, functionContext, contextWriter, root: rootFolder, version);
         }
 
         protected virtual AzureBlobRecordWriter<T> ConstructAzureBlobWriter<T>(string rootContainer,

--- a/Core.Collectors/Core.Collectors.csproj
+++ b/Core.Collectors/Core.Collectors.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.8.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.13.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.DataLake.Store" Version="1.2.3-alpha" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />

--- a/Core.Collectors/Core.Collectors.csproj
+++ b/Core.Collectors/Core.Collectors.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.0.3" />
+    <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.8.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.13.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.DataLake.Store" Version="1.2.3-alpha" />

--- a/Core.Collectors/Web/AdlsClientWrapper2.cs
+++ b/Core.Collectors/Web/AdlsClientWrapper2.cs
@@ -1,38 +1,32 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Azure.DataLake.Store;
+using Azure.Storage;
+using Azure.Storage.Files.DataLake;
 using System;
 
 namespace Microsoft.CloudMine.Core.Collectors.Web
 {
     public interface IAdlsClient2
     {
-        public AdlsClient AdlsClient { get; }
+        public DataLakeServiceClient serviceClient { get; }
     }
 
     public class AdlsClientWrapper2 : IAdlsClient2
     {
-        public static readonly Uri AdlTokenAudience = new Uri(@"https://datalake.azure.net/");
+        public static readonly Uri serviceUri = new Uri(@"https://datalake.azure.net/");
 
-        public AdlsClient AdlsClient { get; private set; }
+        public DataLakeServiceClient serviceClient { get; private set; }
 
         public AdlsClientWrapper2()
         {
-            string adlsAccount = Environment.GetEnvironmentVariable("AdlsAccount2");
-            string adlsTenantId = Environment.GetEnvironmentVariable("AdlsTenantId2");
-            string adlsIngestionApplicationId = Environment.GetEnvironmentVariable("AdlsIngestionApplicationId2");
-            string adlsIngestionApplicationSecret = Environment.GetEnvironmentVariable("AdlsIngestionApplicationSecret2");
+            string storageAccountName = Environment.GetEnvironmentVariable("StorageAccountName");
+            string storageAccountKey = Environment.GetEnvironmentVariable("StorageAccountKey");
 
-            if (string.IsNullOrWhiteSpace(adlsIngestionApplicationId) || string.IsNullOrWhiteSpace(adlsIngestionApplicationSecret) || string.IsNullOrWhiteSpace(adlsAccount) || string.IsNullOrWhiteSpace(adlsTenantId))
-            {
-                // Don't fail loading the function app environment if these variables are not provided. Instead don't initialize the ADLS client.
-                // This way, we permit functions that don't depend on the ADLS client to still run without configuring the ADLS client.
-                // Once the function loads, we will also log the fact that ADLS client is not initialized separately.
-                return;
-            }
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(storageAccountName, storageAccountKey);
 
-            this.AdlsClient = AdlsClientWrapper.InitializeAdlsClient(adlsAccount, adlsTenantId, adlsIngestionApplicationId, adlsIngestionApplicationSecret);
+            // Create DataLakeServiceClient using StorageSharedKeyCredentials
+            this.serviceClient = new DataLakeServiceClient(serviceUri, sharedKeyCredential);
         }
     }
 }


### PR DESCRIPTION
1.Upgrade storage datalake from t1 to t2.

2.Updated files : StorageManager.cs 、 AdlsBulkRecordWriter.cs 、 AdlsClientWrapper.cs  、 AdlsClientWrapper2.cs 

3.Microsoft.Azure.KeyVault referenced in Core.Collectors.Test.csproj, but not used in code, deleted it.

@scottaddie , @AlexGhiondea , @kyle-patterson , @tg-msft , @amishra-dev for notification.