### PR TITLE
Support dual writing for ADO Collectors

### DIFF
--- a/Core.Collectors/Core.Collectors.csproj
+++ b/Core.Collectors/Core.Collectors.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Microsoft.CloudMine.Core.Collectors</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Data.Tables" Version="12.2.1" />
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.0.3" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.13.1" />

--- a/Core.Collectors/Web/RateLimiter.cs
+++ b/Core.Collectors/Web/RateLimiter.cs
@@ -20,8 +20,10 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
         private static readonly long? RateLimitOverride;
 
         private readonly ICache<RateLimitTableEntity> rateLimiterCache;
+        private readonly ICache<RateLimitTableEntity> rateLimiterCacheCosmosDb;
         protected ITelemetryClient TelemetryClient { get; private set; }
         private readonly bool expectRateLimitingHeaders;
+        private readonly bool enableDualWriting;
 
         protected string OrganizationId { get; private set; }
         protected string OrganizationName { get; private set; }
@@ -48,6 +50,17 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
         public RateLimiter(string organizationId,
                            string organizationName,
                            ICache<RateLimitTableEntity> rateLimiterCache,
+                           ICache<RateLimitTableEntity> rateLimiterCacheCosmosDb,
+                           ITelemetryClient telemetryClient,
+                           bool expectRateLimitingHeaders,
+                           bool enableDualWriting)
+            : this(organizationId, organizationName, rateLimiterCache, rateLimiterCacheCosmosDb, telemetryClient, expectRateLimitingHeaders, enableDualWriting, cacheInvalidationFrequency: TimeSpan.FromTicks(0))
+        {
+        }
+
+        public RateLimiter(string organizationId,
+                           string organizationName,
+                           ICache<RateLimitTableEntity> rateLimiterCache,
                            ITelemetryClient telemetryClient,
                            bool expectRateLimitingHeaders,
                            TimeSpan cacheInvalidationFrequency)
@@ -57,6 +70,28 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
             this.rateLimiterCache = rateLimiterCache;
             this.TelemetryClient = telemetryClient;
             this.expectRateLimitingHeaders = expectRateLimitingHeaders;
+            this.cacheInvalidationFrequency = cacheInvalidationFrequency;
+
+            this.cachedResult = null;
+            this.cacheDateUtc = DateTime.MinValue;
+        }
+
+        public RateLimiter(string organizationId,
+                           string organizationName,
+                           ICache<RateLimitTableEntity> rateLimiterCache,
+                           ICache<RateLimitTableEntity> rateLimiterCacheCosmosDb,
+                           ITelemetryClient telemetryClient,
+                           bool expectRateLimitingHeaders,
+                           bool enableDualWriting,
+                           TimeSpan cacheInvalidationFrequency)
+        {
+            this.OrganizationId = organizationId;
+            this.OrganizationName = organizationName;
+            this.rateLimiterCache = rateLimiterCache;
+            this.rateLimiterCacheCosmosDb = rateLimiterCacheCosmosDb;
+            this.TelemetryClient = telemetryClient;
+            this.expectRateLimitingHeaders = expectRateLimitingHeaders;
+            this.enableDualWriting = enableDualWriting;
             this.cacheInvalidationFrequency = cacheInvalidationFrequency;
 
             this.cachedResult = null;
@@ -83,7 +118,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
                 rateLimitResetDate = Epoch.AddSeconds(rateLimitReset);
             }
 
-            // When this method is called, it is expected that some of the required headers (e.g., rate-limit limit) might be missing. 
+            // When this method is called, it is expected that some of the required headers (e.g., rate-limit limit) might be missing.
             // Since the goal of this method is to update "Retry-After" column stored, permit those missing values and instead keep the existing values stored (if any).
             RateLimitTableEntity existingRecord = await this.rateLimiterCache.RetrieveAsync(new RateLimitTableEntity(identity, this.OrganizationId, this.OrganizationName)).ConfigureAwait(false);
             if (existingRecord == null)
@@ -98,6 +133,10 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
 
             this.cachedResult = new RateLimitTableEntity(identity, this.OrganizationId, this.OrganizationName, rateLimitLimit, rateLimitRemaining, rateLimitResetDate, retryAfterDate);
             await this.rateLimiterCache.CacheAsync(this.cachedResult).ConfigureAwait(false);
+            if (this.enableDualWriting)
+            {
+                await this.rateLimiterCacheCosmosDb.CacheAsync(this.cachedResult).ConfigureAwait(false);
+            }
             this.cacheDateUtc = DateTime.UtcNow;
         }
 
@@ -152,7 +191,12 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
                 return;
             }
 
-            await this.rateLimiterCache.CacheAsync(new RateLimitTableEntity(identity, this.OrganizationId, this.OrganizationName, rateLimitLimit, rateLimitRemaining, rateLimitResetDate, retryAfterDate)).ConfigureAwait(false);
+            RateLimitTableEntity rateLimitTableEntity = new RateLimitTableEntity(identity, this.OrganizationId, this.OrganizationName, rateLimitLimit, rateLimitRemaining, rateLimitResetDate, retryAfterDate);
+            await this.rateLimiterCache.CacheAsync(rateLimitTableEntity).ConfigureAwait(false);
+            if (this.enableDualWriting)
+            {
+                await this.rateLimiterCacheCosmosDb.CacheAsync(rateLimitTableEntity).ConfigureAwait(false);
+            }
         }
 
         public static long GetRetryAfter(HttpResponseHeaders responseHeaders)


### PR DESCRIPTION
These changes technically aren't in the spirit of a "Core" collector, however, are necessary to enable dual rate limiting cache writes in ADO collectors. This also adds some packages that will be used in the future as we move to a newer version of .NET. 

This is a draft PR to get feedback.