### PR TITLE
[Storage] Migrate sdk storage from track1 to track2

### DIFF
--- a/Core.Collectors.Tests/Core.Collectors.Tests.csproj
+++ b/Core.Collectors.Tests/Core.Collectors.Tests.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />

--- a/Core.Collectors/Cache/AzureTableCache.cs
+++ b/Core.Collectors/Cache/AzureTableCache.cs
@@ -3,11 +3,11 @@
 
 using Microsoft.CloudMine.Core.Collectors.IO;
 using Microsoft.CloudMine.Core.Collectors.Telemetry;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
+using Azure.Data.Tables;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Azure;
 
 namespace Microsoft.CloudMine.Core.Collectors.Cache
 {
@@ -17,7 +17,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Cache
         private readonly string name;
         private readonly string storageConnectionEnvironmentVariable;
 
-        private CloudTable table;
+        private TableClient table;
         private bool initialized;
 
         public AzureTableCache(ITelemetryClient telemetryClient, string name, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
@@ -28,7 +28,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Cache
             this.storageConnectionEnvironmentVariable = storageConnectionEnvironmentVariable;
         }
 
-        public AzureTableCache(ITelemetryClient telemetryClient, CloudTable table)
+        public AzureTableCache(ITelemetryClient telemetryClient, TableClient table)
         {
             this.telemetryClient = telemetryClient;
             this.table = table;
@@ -57,11 +57,10 @@ namespace Microsoft.CloudMine.Core.Collectors.Cache
                 return;
             }
 
-            TableOperation insertOrReplaceOperation = TableOperation.InsertOrReplace(tableEntity);
             try
             {
-                TableResult insertOrReplaceResult = await this.table.ExecuteAsync(insertOrReplaceOperation).ConfigureAwait(false);
-                int insertOrReplaceStatusCode = insertOrReplaceResult.HttpStatusCode;
+                var insertOrReplaceResult = await this.table.UpsertEntityAsync<TableEntityWithContext>(tableEntity, TableUpdateMode.Merge).ConfigureAwait(false);
+                int insertOrReplaceStatusCode = insertOrReplaceResult.Status;
                 // 204: no content => InsertOrReplace operation does not return any content when successful.
                 if (insertOrReplaceStatusCode != 204)
                 {
@@ -89,16 +88,15 @@ namespace Microsoft.CloudMine.Core.Collectors.Cache
         {
             if (currentTableEntity == null)
             {
-                TableOperation insertOperation = TableOperation.Insert(newTableEntity);
                 try
                 {
-                    await this.table.ExecuteAsync(insertOperation).ConfigureAwait(false);
+                    await this.table.UpsertEntityAsync<TableEntityWithContext>(newTableEntity, TableUpdateMode.Merge).ConfigureAwait(false);
                     return true;
                 }
-                catch (Exception insertException) when (insertException is StorageException)
+                catch (Exception insertException) when (insertException is RequestFailedException)
                 {
-                    StorageException insertStorageException = (StorageException)insertException;
-                    int insertStatusCode = insertStorageException.RequestInformation.HttpStatusCode;
+                    RequestFailedException insertStorageException = (RequestFailedException)insertException;
+                    int insertStatusCode = insertStorageException.Status;
                     if (insertStatusCode != 409) // Ignore 409, since it (Conflict) indicates that someone else did the update before us.
                     {
                         Dictionary<string, string> properties = new Dictionary<string, string>()
@@ -114,18 +112,17 @@ namespace Microsoft.CloudMine.Core.Collectors.Cache
                 return false;
             }
 
-            string currentETag = currentTableEntity.ETag;
+            ETag currentETag = currentTableEntity.ETag;
             newTableEntity.ETag = currentETag;
-            TableOperation replaceOperation = TableOperation.Replace(newTableEntity);
             try
             {
-                await this.table.ExecuteAsync(replaceOperation).ConfigureAwait(false);
+                await this.table.UpsertEntityAsync<TableEntityWithContext>(newTableEntity, TableUpdateMode.Replace).ConfigureAwait(false);
                 return true;
             }
-            catch (Exception replaceException) when (replaceException is StorageException)
+            catch (Exception replaceException) when (replaceException is RequestFailedException)
             {
-                StorageException replaceStorageException = (StorageException)replaceException;
-                int replaceStatusCode = replaceStorageException.RequestInformation.HttpStatusCode;
+                RequestFailedException replaceStorageException = (RequestFailedException)replaceException;
+                int replaceStatusCode = replaceStorageException.Status;
                 if (replaceStatusCode != 412) // Ignore 412, since it (Pre-condition failed) indicates that someone else did the update before us.
                 {
                     Dictionary<string, string> properties = new Dictionary<string, string>()
@@ -149,11 +146,10 @@ namespace Microsoft.CloudMine.Core.Collectors.Cache
                 return null;
             }
 
-            TableOperation retrieveOperation = TableOperation.Retrieve<T>(tableEntity.PartitionKey, tableEntity.RowKey);
             try
             {
-                TableResult retrieveResult = await this.table.ExecuteAsync(retrieveOperation).ConfigureAwait(false);
-                int retrieveStatusCode = retrieveResult.HttpStatusCode;
+                var retrieveResult = await this.table.GetEntityAsync<TableEntityWithContext>(tableEntity.PartitionKey, tableEntity.RowKey).ConfigureAwait(false);
+                int retrieveStatusCode = retrieveResult.GetRawResponse().Status;
                 // 200: OK => The item exists in the cache and retrieve was successful.
                 // 404: Does not exist => The item does not exist in the cache.
                 if (retrieveStatusCode != 200 && retrieveStatusCode != 404) 
@@ -166,7 +162,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Cache
                     this.telemetryClient.TrackEvent("CachingError", properties);
                 }
 
-                return (T)retrieveResult.Result;
+                return (T)retrieveResult.Value;
             }
             catch (Exception exception)
             {

--- a/Core.Collectors/Cache/TableEntityWithContext.cs
+++ b/Core.Collectors/Cache/TableEntityWithContext.cs
@@ -1,14 +1,21 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.WindowsAzure.Storage.Table;
+using Azure;
+using Azure.Data.Tables;
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.CloudMine.Core.Collectors.Cache
 {
-    public abstract class TableEntityWithContext : TableEntity
+    public class TableEntityWithContext : ITableEntity
     {
         private readonly Dictionary<string, string> context;
+
+        public string PartitionKey { get; set; }
+        public string RowKey { get; set; }
+        public DateTimeOffset? Timestamp { get; set; }
+        public ETag ETag { get; set; }
 
         public TableEntityWithContext()
         {

--- a/Core.Collectors/Config/StorageManager.cs
+++ b/Core.Collectors/Config/StorageManager.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Azure.DataLake.Store;
+using Azure.Storage.Files.DataLake;
 using Microsoft.CloudMine.Core.Collectors.Context;
 using Microsoft.CloudMine.Core.Collectors.Error;
 using Microsoft.CloudMine.Core.Collectors.IO;
@@ -28,7 +28,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Config
             this.initialized = false;
         }
 
-        public List<IRecordWriter> InitializeRecordWriters<T>(string identifier, T functionContext, ContextWriter<T> contextWriter, AdlsClient adlsClient) where T : FunctionContext
+        public List<IRecordWriter> InitializeRecordWriters<T>(string identifier, T functionContext, ContextWriter<T> contextWriter, DataLakeServiceClient adlsClient) where T : FunctionContext
         {
             if (this.initialized)
             {
@@ -110,7 +110,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Config
             return this.ConstructAzureBlobWriter(rootContainer, outputQueueName, identifier, this.telemetryClient, functionContext, contextWriter, storageConnectionEnvironmentVariable, notificationQueueEnvironmentVariable);
         }
 
-        private IRecordWriter InitializeAdlsBulkRecordWriter<T>(JToken recordWriterToken, AdlsClient adlsClient, string identifier, T functionContext, ContextWriter<T> contextWriter) where T : FunctionContext
+        private IRecordWriter InitializeAdlsBulkRecordWriter<T>(JToken recordWriterToken, DataLakeServiceClient adlsClient, string identifier, T functionContext, ContextWriter<T> contextWriter) where T : FunctionContext
         {
             JToken rootFolderToken = recordWriterToken.SelectToken("RootFolder");
             JToken versionToken = recordWriterToken.SelectToken("Version");

--- a/Core.Collectors/Core.Collectors.csproj
+++ b/Core.Collectors/Core.Collectors.csproj
@@ -5,18 +5,15 @@
     <RootNamespace>Microsoft.CloudMine.Core.Collectors</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.1.1" />
-    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.0.3" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.13.1" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.4.0" />
+    <PackageReference Include="Azure.Identity" Version="1.5.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
+    <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.8.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.DataLake.Store" Version="1.2.3-alpha" />
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.10.0" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage.Queues" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
 </Project>

--- a/Core.Collectors/IO/AdlsBulkRecordWriter.cs
+++ b/Core.Collectors/IO/AdlsBulkRecordWriter.cs
@@ -3,11 +3,10 @@
 
 using Microsoft.CloudMine.Core.Collectors.Context;
 using Microsoft.CloudMine.Core.Collectors.Telemetry;
-using Microsoft.Azure.DataLake.Store;
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Azure.DataLake.Store.FileTransfer;
+using Azure.Storage.Files.DataLake;
 using Microsoft.CloudMine.Core.Collectors.Error;
 using System.Diagnostics;
 using System.Collections.Generic;
@@ -16,11 +15,11 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
 {
     public class AdlsConfig
     {
-        public AdlsClient AdlsClient { get; }
+        public DataLakeServiceClient AdlsClient { get; }
         public string AdlsRoot { get; }
         public string Version { get; }
 
-        public AdlsConfig(AdlsClient adlsClient, string adlsRoot, string version)
+        public AdlsConfig(DataLakeServiceClient adlsClient, string adlsRoot, string version)
         {
             this.AdlsClient = adlsClient;
             this.AdlsRoot = adlsRoot;
@@ -44,7 +43,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
         private string currentLocalPath;
 
         // Keeping this constructor for backwards compatibility for now.
-        public AdlsBulkRecordWriter(AdlsClient adlsClient,
+        public AdlsBulkRecordWriter(DataLakeServiceClient adlsClient,
                                     string identifier,
                                     ITelemetryClient telemetryClient,
                                     T functionContext,
@@ -166,30 +165,16 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
         {
             Stopwatch uploadTimer = Stopwatch.StartNew();
             string adlsDirectory = $"{adlsConfig.AdlsRoot}/{adlsConfig.Version}";
-
-            TransferStatus status = adlsConfig.AdlsClient.BulkUpload(this.localRoot, adlsDirectory);
-            bool retried = false;
-            if (status.EntriesFailed.Count != 0)
+            DataLakeFileSystemClient filesystem = adlsConfig.AdlsClient.GetFileSystemClient("sample-filesystem-append");
+            filesystem.Create();
+            try {
+                DataLakeFileClient file = filesystem.GetFileClient(adlsDirectory);
+                file.Create();
+                file.Upload(File.OpenRead(this.localRoot), true);
+            }
+            finally
             {
-                retried = true;
-                // Retry once.
-                status = adlsConfig.AdlsClient.BulkUpload(this.localRoot, adlsDirectory, shouldOverwrite: IfExists.Fail);
-                if (status.EntriesFailed.Count != 0)
-                {
-                    foreach (SingleEntryTransferStatus failedTransferStatus in status.EntriesFailed)
-                    {
-                        Dictionary<string, string> transferStatusProperties = new Dictionary<string, string>()
-                        {
-                            { "EntryName", failedTransferStatus.EntryName },
-                            { "EntrySize", failedTransferStatus.EntrySize.ToString() },
-                            { "TransferErrors", failedTransferStatus.Errors },
-                            { "TransferStatus", failedTransferStatus.Status.ToString() },
-                            { "TransferType", failedTransferStatus.Type.ToString() },
-                        };
-                        this.TelemetryClient.TrackEvent("FailedTransferStatus", transferStatusProperties);
-                    }
-                    throw new FatalException($"Cannot bulk upload '{finalOutputPath}'.");
-                }
+                filesystem.Delete();
             }
 
             uploadTimer.Stop();
@@ -198,7 +183,6 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             Dictionary<string, string> properties = new Dictionary<string, string>()
             {
                 { "Duration", uploadDuration.ToString() },
-                { "Retried", retried.ToString() },
                 { "SizeBytes", this.SizeInBytes.ToString() },
                 { "LocalPath", finalOutputPath },
             };

--- a/Core.Collectors/IO/AzureBlobRecordWriter.cs
+++ b/Core.Collectors/IO/AzureBlobRecordWriter.cs
@@ -3,8 +3,9 @@
 
 using Microsoft.CloudMine.Core.Collectors.Context;
 using Microsoft.CloudMine.Core.Collectors.Telemetry;
-using Microsoft.WindowsAzure.Storage.Blob;
-using Microsoft.WindowsAzure.Storage.Queue;
+using Azure.Storage.Blobs;
+using Azure.Storage.Queues;
+using Azure.Storage.Blobs.Specialized;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -21,9 +22,9 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
         private readonly string storageConnectionEnvironmentVariable;
         private readonly string notificationQueueConnectionEnvironmentVariable;
 
-        private CloudBlobContainer outContainer;
-        private CloudBlockBlob outputBlob;
-        private CloudQueue queue;
+        private BlobContainerClient outContainer;
+        private BlockBlobClient outputBlob;
+        private QueueClient queue;
 
         public AzureBlobRecordWriter(string blobRoot,
                                      string outputQueueName,
@@ -49,8 +50,8 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
 
         protected override async Task<StreamWriter> NewStreamWriterAsync(string suffix)
         {
-            this.outputBlob = this.outContainer.GetBlockBlobReference($"{this.OutputPathPrefix}{suffix}.json");
-            CloudBlobStream cloudBlobStream = await this.outputBlob.OpenWriteAsync().ConfigureAwait(false);
+            this.outputBlob = this.outContainer.GetBlockBlobClient($"{this.OutputPathPrefix}{suffix}.json");
+            Stream cloudBlobStream = await this.outputBlob.OpenWriteAsync(true).ConfigureAwait(false);
             return new StreamWriter(cloudBlobStream, Encoding.UTF8);
         }
 
@@ -59,7 +60,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             string notificiationMessage = AzureHelpers.GenerateNotificationMessage(this.outputBlob);
             if (this.queue != null)
             {
-                await this.queue.AddMessageAsync(new CloudQueueMessage(notificiationMessage)).ConfigureAwait(false);
+                await this.queue.SendMessageAsync(notificiationMessage).ConfigureAwait(false);
             }
 
             this.AddOutputPath(this.outputBlob.Name);

--- a/Core.Collectors/IO/AzureHelpers.cs
+++ b/Core.Collectors/IO/AzureHelpers.cs
@@ -1,14 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Blob;
-using Microsoft.WindowsAzure.Storage.Queue;
-using Microsoft.WindowsAzure.Storage.Table;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure;
+using Azure.Storage.Sas;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Queues;
+using Azure.Storage.Queues.Models;
+using Azure.Data.Tables;
 
 namespace Microsoft.CloudMine.Core.Collectors.IO
 {
@@ -20,54 +23,54 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
 
         public class CachedCloudQueue
         {
-            public CloudQueue CloudQueue { get; }
+            public QueueClient CloudQueue { get; }
             public DateTime LastInitializationDateUtc { get; }
 
-            public CachedCloudQueue(CloudQueue cloudQueue, DateTime lastInitializationDateUtc)
+            public CachedCloudQueue(QueueClient cloudQueue, DateTime lastInitializationDateUtc)
             {
                 this.CloudQueue = cloudQueue;
                 this.LastInitializationDateUtc = lastInitializationDateUtc;
             }
         }
 
-        private static CloudStorageAccount GetStorageAccount(string storageConnectionEnvironmentVariable)
+        private static string GetStorageAccount(string storageConnectionEnvironmentVariable)
         {
             string stagingBlobConnectionString = Environment.GetEnvironmentVariable(storageConnectionEnvironmentVariable);
-            return CloudStorageAccount.Parse(stagingBlobConnectionString);
+            return stagingBlobConnectionString;
         }
 
         public static async Task<string> GetBlobContentAsync(string container, string path, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
         {
-            CloudBlockBlob blob = GetBlob(container, path, storageConnectionEnvironmentVariable);
-            string content = await blob.DownloadTextAsync();
+            BlockBlobClient blob = GetBlob(container, path, storageConnectionEnvironmentVariable);
+            string content = (await blob.DownloadContentAsync()).Value.Content.ToString();
             // Ignore BOM character at the beginning of the file, which can happen due to encoding.
             // '\uFEFF' => BOM
             return content[0] == '\uFEFF' ? content.Substring(1) : content;
         }
 
-        public static CloudBlockBlob GetBlob(string container, string path, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
+        public static BlockBlobClient GetBlob(string container, string path, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
         {
-            CloudBlobContainer blobContainer = GetBlobContainer(container, storageConnectionEnvironmentVariable);
-            CloudBlockBlob blob = blobContainer.GetBlockBlobReference(path);
+            BlobContainerClient blobContainer = GetBlobContainer(container, storageConnectionEnvironmentVariable);
+            BlockBlobClient blob = blobContainer.GetBlockBlobClient(path);
             return blob;
         }
 
-        public static CloudBlobContainer GetBlobContainer(string container, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
+        public static BlobContainerClient GetBlobContainer(string container, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
         {
-            CloudStorageAccount storageAccount = GetStorageAccount(storageConnectionEnvironmentVariable);
-            CloudBlobClient storageBlobClient = storageAccount.CreateCloudBlobClient();
-            CloudBlobContainer blobContainer = storageBlobClient.GetContainerReference(container);
+            string connectionString = GetStorageAccount(storageConnectionEnvironmentVariable);
+            BlobServiceClient blobServiceClient = new BlobServiceClient(connectionString);
+            BlobContainerClient blobContainer = blobServiceClient.GetBlobContainerClient(container);
             return blobContainer;
         }
 
-        public static async Task<CloudBlobContainer> GetStorageContainerAsync(string container, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
+        public static async Task<BlobContainerClient> GetStorageContainerAsync(string container, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
         {
-            CloudBlobContainer storageContainer = GetBlobContainer(container, storageConnectionEnvironmentVariable);
+            BlobContainerClient storageContainer = GetBlobContainer(container, storageConnectionEnvironmentVariable);
             await storageContainer.CreateIfNotExistsAsync().ConfigureAwait(false);
             return storageContainer;
         }
 
-        public static async Task<CloudQueue> GetStorageQueueCachedAsync(string queueName, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
+        public static async Task<QueueClient> GetStorageQueueCachedAsync(string queueName, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
         {
             await CloudResourceLock.WaitAsync().ConfigureAwait(false);
             try
@@ -75,7 +78,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
                 string key = $"{queueName}:{storageConnectionEnvironmentVariable}";
                 if (!CloudQueues.TryGetValue(key, out CachedCloudQueue cachedCloudQueue) || (DateTime.UtcNow - cachedCloudQueue.LastInitializationDateUtc) >= CloudResourcesInitializitonFrequency)
                 {
-                    CloudQueue cloudQueue = await GetStorageQueueAsync(queueName, storageConnectionEnvironmentVariable).ConfigureAwait(false);
+                    QueueClient cloudQueue = await GetStorageQueueAsync(queueName, storageConnectionEnvironmentVariable).ConfigureAwait(false);
                     cachedCloudQueue = new CachedCloudQueue(cloudQueue, DateTime.UtcNow);
                     CloudQueues[key] = cachedCloudQueue;
                 }
@@ -88,51 +91,46 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             }
         }
 
-        public static async Task<CloudQueue> GetStorageQueueAsync(string queueName, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
+        public static async Task<QueueClient> GetStorageQueueAsync(string queueName, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
         {
-            CloudStorageAccount storageAccount = GetStorageAccount(storageConnectionEnvironmentVariable);
-            CloudQueueClient queueClient = storageAccount.CreateCloudQueueClient();
-            CloudQueue queue = queueClient.GetQueueReference(queueName);
+            string connectionString = GetStorageAccount(storageConnectionEnvironmentVariable);
+            QueueClient queue = new QueueClient(connectionString, queueName);
             await queue.CreateIfNotExistsAsync().ConfigureAwait(false);
             return queue;
         }
 
-        public static async Task<List<CloudQueue>> ListStorageQueuesAsync(string prefix, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
+        public static async Task<List<QueueItem>> ListStorageQueuesAsync(string prefix, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
         {
-            List<CloudQueue> result = new List<CloudQueue>();
+            List<QueueItem> result = new List<QueueItem>();
 
-            CloudStorageAccount storageAccount = GetStorageAccount(storageConnectionEnvironmentVariable);
-            CloudQueueClient queueClient = storageAccount.CreateCloudQueueClient();
-            QueueContinuationToken continuationToken = null;
-            do
-            {
-                QueueResultSegment queueResultSegment = await queueClient.ListQueuesSegmentedAsync(prefix, continuationToken).ConfigureAwait(false);
-                continuationToken = queueResultSegment.ContinuationToken;
-
-                result.AddRange(queueResultSegment.Results);
-            } while (continuationToken != null);
+            string connectionString = GetStorageAccount(storageConnectionEnvironmentVariable);
+            QueueServiceClient queueServiceClient = new QueueServiceClient(connectionString);
+            await foreach (Page<QueueItem> page in queueServiceClient.GetQueuesAsync(prefix: prefix).AsPages()) {
+                result.AddRange(page.Values);
+            }
 
             return result;
         }
 
-        public static async Task<CloudTable> GetStorageTableAsync(string tableName, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
+        public static async Task<TableClient> GetStorageTableAsync(string tableName, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
         {
-            CloudStorageAccount storageAccount = GetStorageAccount(storageConnectionEnvironmentVariable);
-            CloudTableClient tableClient = storageAccount.CreateCloudTableClient();
-            CloudTable table = tableClient.GetTableReference(tableName);
+            string connectionString = GetStorageAccount(storageConnectionEnvironmentVariable);
+            TableServiceClient tableClient = new TableServiceClient(connectionString);
+            TableClient table = tableClient.GetTableClient(tableName);
             await table.CreateIfNotExistsAsync().ConfigureAwait(false);
             return table;
         }
 
-        public static string GenerateNotificationMessage(CloudBlob blob)
+        public static string GenerateNotificationMessage(BlobBaseClient blob)
         {
-            string blobSas = blob.GetSharedAccessSignature(new SharedAccessBlobPolicy()
+
+            BlobSasBuilder blobSasBuilder = new BlobSasBuilder(permissions: BlobContainerSasPermissions.Read | BlobContainerSasPermissions.List, expiresOn: DateTimeOffset.UtcNow.AddDays(7))
             {
-                Permissions = SharedAccessBlobPermissions.Read | SharedAccessBlobPermissions.List,
-                SharedAccessStartTime = DateTimeOffset.UtcNow,
-                SharedAccessExpiryTime = DateTimeOffset.UtcNow.AddDays(7)
-            });
-            string blobUriSas = string.Concat(blob.Uri, blobSas);
+                StartsOn = DateTimeOffset.UtcNow
+            };
+
+            Uri sasUri = blob.GenerateSasUri(blobSasBuilder);
+            string blobUriSas = sasUri.ToString();
             string notificiationMessage = $"AzureBlob: 1.0\n{{\"BlobRecords\": [{{\"Path\": \"{blobUriSas}\"}}]}}";
             return notificiationMessage;
         }

--- a/Core.Collectors/IO/AzureHelpers.cs
+++ b/Core.Collectors/IO/AzureHelpers.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             return queue;
         }
 
-        public static async Task<List<QueueItem>> ListStorageQueuesAsync(string prefix, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
+        public static async Task<List<QueueClient>> ListStorageQueuesAsync(string prefix, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
         {
             List<QueueItem> result = new List<QueueItem>();
 
@@ -120,11 +120,17 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             await foreach (Page<QueueItem> page in queueServiceClient.GetQueuesAsync(prefix: prefix).AsPages()) {
                 result.AddRange(page.Values);
             }
+            List<QueueClient> clientResult = new List<QueueClient>();
+            foreach (QueueItem queueItem in result)
+            {
+                QueueClient queueClient = new QueueClient(connectionString, queueItem.Name);
+                clientResult.Add(queueClient);
+            }
 
-            return result;
+            return clientResult;
         }
 
-        public static async Task<List<QueueItem>> ListStorageQueuesAsync(string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
+        public static async Task<List<QueueClient>> ListStorageQueuesAsync(string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")
         {
             List<QueueItem> result = new List<QueueItem>();
             string connectionString = GetStorageAccount(storageConnectionEnvironmentVariable);
@@ -133,7 +139,14 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             {
                 result.AddRange(page.Values);
             }
-            return result;
+            List<QueueClient> clientResult = new List<QueueClient>();
+            foreach (QueueItem queueItem in result)
+            {
+                QueueClient queueClient = new QueueClient(connectionString, queueItem.Name);
+                clientResult.Add(queueClient);
+            }
+
+            return clientResult;
         }
 
         public static async Task<TableClient> GetStorageTableAsync(string tableName, string storageConnectionEnvironmentVariable = "AzureWebJobsStorage")

--- a/Core.Collectors/IO/CloudQueueWrapper.cs
+++ b/Core.Collectors/IO/CloudQueueWrapper.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Queue;
+using Azure.Storage.Queues;
 using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
@@ -11,9 +10,9 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
 {
     public class CloudQueueWrapper : IQueue
     {
-        private readonly CloudQueue queue;
+        private readonly QueueClient queue;
 
-        public CloudQueueWrapper(CloudQueue queue)
+        public CloudQueueWrapper(QueueClient queue)
         {
             this.queue = queue;
         }
@@ -26,12 +25,12 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
 
         public Task PutMessageAsync(string message)
         {
-            return this.queue.AddMessageAsync(new CloudQueueMessage(message));
+            return this.queue.SendMessageAsync(message);
         }
 
         public Task PutMessageAsync(string message, TimeSpan timeToLive)
         {
-            return this.queue.AddMessageAsync(new CloudQueueMessage(message), timeToLive, null, new QueueRequestOptions(), new OperationContext());
+            return this.queue.SendMessageAsync(message, null, timeToLive);
         }
 
         public Task PutObjectAsJsonStringAsync(object obj, TimeSpan timeToLive)

--- a/Core.Collectors/IO/SplitAzureBlobRecordWriter.cs
+++ b/Core.Collectors/IO/SplitAzureBlobRecordWriter.cs
@@ -5,8 +5,8 @@ using Microsoft.CloudMine.Core.Collectors.Context;
 using Microsoft.CloudMine.Core.Collectors.Error;
 using Microsoft.CloudMine.Core.Collectors.Telemetry;
 using Microsoft.CloudMine.Core.Collectors.Utility;
-using Microsoft.WindowsAzure.Storage.Blob;
-using Microsoft.WindowsAzure.Storage.Queue;
+using Azure.Storage.Blobs;
+using Azure.Storage.Queues;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -16,6 +16,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Azure.Storage.Blobs.Specialized;
 
 namespace Microsoft.CloudMine.Core.Collectors.IO
 {
@@ -28,7 +29,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
         private readonly string notificationQueuePrefix;
         private readonly string storageConnectionEnvironmentVariable;
 
-        private CloudBlobContainer outContainer;
+        private BlobContainerClient outContainer;
 
         private readonly T functionContext;
         private readonly ContextWriter<T> contextWriter;
@@ -267,7 +268,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
         private class WriterState : IDisposable
         {
             protected long SizeInBytes { get; private set; }
-            public CloudBlockBlob OutputBlob { get; private set; }
+            public BlockBlobClient OutputBlob { get; private set; }
             public List<string> FinalizedOutputPaths { get; private set; }
             private IQueue notificationQueue;
 
@@ -275,7 +276,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             private readonly string blobRoot;
             private readonly string outputPath;
             private StreamWriter writer;
-            private readonly CloudBlobContainer outContainer;
+            private readonly BlobContainerClient outContainer;
             private readonly string notificationQueuePrefix;
             private readonly string storageConnectionEnvironmentVariable;
 
@@ -284,7 +285,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             private long recordCount;
             private DateTime minCollectionDateUtc;
 
-            public WriterState(string recordType, string blobRoot, string outputPath, string notificationQueuePrefix, string storageConnectionEnvironmentVariable, CloudBlobContainer outContainer)
+            public WriterState(string recordType, string blobRoot, string outputPath, string notificationQueuePrefix, string storageConnectionEnvironmentVariable, BlobContainerClient outContainer)
             {
                 this.recordType = recordType;
                 this.blobRoot = blobRoot;
@@ -306,8 +307,8 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             {
                 this.fileIndex++;
                 string suffix = fileIndex == 0 ? "" : $"_{fileIndex}";
-                this.OutputBlob = outContainer.GetBlockBlobReference($"{this.recordType}/{this.outputPath}{suffix}.json");
-                CloudBlobStream cloudBlobStream = await this.OutputBlob.OpenWriteAsync().ConfigureAwait(false);
+                this.OutputBlob = outContainer.GetBlockBlobClient($"{this.recordType}/{this.outputPath}{suffix}.json");
+                Stream cloudBlobStream = await this.OutputBlob.OpenWriteAsync(true).ConfigureAwait(false);
                 this.writer = new StreamWriter(cloudBlobStream, Encoding.UTF8);
 
                 // Initialize the notification queue only once since we keep using the same queue even for multiple files.
@@ -321,7 +322,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
                         // Azure queue names are limited with 63 characters. Use only the first 63 characters.
                         queueName = queueName.Substring(0, 63);
                     }
-                    CloudQueue queue = await AzureHelpers.GetStorageQueueCachedAsync(queueName, this.storageConnectionEnvironmentVariable).ConfigureAwait(false);
+                    QueueClient queue = await AzureHelpers.GetStorageQueueCachedAsync(queueName, this.storageConnectionEnvironmentVariable).ConfigureAwait(false);
                     this.notificationQueue = new CloudQueueWrapper(queue);
                 }
 

--- a/Core.Collectors/Web/AdlsClientWrapper2.cs
+++ b/Core.Collectors/Web/AdlsClientWrapper2.cs
@@ -1,21 +1,21 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Azure.DataLake.Store;
+using Azure.Storage.Files.DataLake;
 using System;
 
 namespace Microsoft.CloudMine.Core.Collectors.Web
 {
     public interface IAdlsClient2
     {
-        public AdlsClient AdlsClient { get; }
+        public DataLakeServiceClient AdlsClient { get; }
     }
 
     public class AdlsClientWrapper2 : IAdlsClient2
     {
         public static readonly Uri AdlTokenAudience = new Uri(@"https://datalake.azure.net/");
 
-        public AdlsClient AdlsClient { get; private set; }
+        public DataLakeServiceClient AdlsClient { get; private set; }
 
         public AdlsClientWrapper2()
         {
@@ -23,6 +23,10 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
             string adlsTenantId = Environment.GetEnvironmentVariable("AdlsTenantId2");
             string adlsIngestionApplicationId = Environment.GetEnvironmentVariable("AdlsIngestionApplicationId2");
             string adlsIngestionApplicationSecret = Environment.GetEnvironmentVariable("AdlsIngestionApplicationSecret2");
+
+            Uri serviceUri = new Uri(Environment.GetEnvironmentVariable("AdlsServiceUri2"));
+            string storageAccountName = Environment.GetEnvironmentVariable("storageAccountName2");
+            string storageAccountKey = Environment.GetEnvironmentVariable("storageAccountKey2");
 
             if (string.IsNullOrWhiteSpace(adlsIngestionApplicationId) || string.IsNullOrWhiteSpace(adlsIngestionApplicationSecret) || string.IsNullOrWhiteSpace(adlsAccount) || string.IsNullOrWhiteSpace(adlsTenantId))
             {
@@ -32,7 +36,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
                 return;
             }
 
-            this.AdlsClient = AdlsClientWrapper.InitializeAdlsClient(adlsAccount, adlsTenantId, adlsIngestionApplicationId, adlsIngestionApplicationSecret);
+            this.AdlsClient = AdlsClientWrapper.InitializeAdlsClient(serviceUri, storageAccountName, storageAccountKey);
         }
     }
 }


### PR DESCRIPTION
1. Upgrade this repository to use the new Azure.Storage.* packages.

2. Remove old WindowsAzure.Storage, Microsoft.Azure.DataLake.Store packages.

We are migrating all sdk services used in [CloudMine](https://dev.azure.com/mseng/Domino/_git/CloudMine) repo, and this repo was referenced in it, so we need upgrade this one first.

@scottaddie, @AlexGhiondea, @kyle-patterson, @tg-msft, @amishra-dev for notification.