### PR TITLE
Maintain a file map in ADLS bulk upload.

### DIFF
--- a/Core.Collectors.Tests/IO/InMemoryRecordWriter.cs
+++ b/Core.Collectors.Tests/IO/InMemoryRecordWriter.cs
@@ -50,6 +50,11 @@ namespace Microsoft.CloudMine.Core.Collectors.Tests.IO
             return Task.CompletedTask;
         }
 
+        public void AddFilePath(string filePath)
+        {
+            // No file mapping is done in split azure blob writer, so ignore.
+        }
+
         public void SetOutputPathPrefix(string outputPathPrefix)
         {
             throw new NotImplementedException();

--- a/Core.Collectors/IO/AzureBlobRecordWriter.cs
+++ b/Core.Collectors/IO/AzureBlobRecordWriter.cs
@@ -64,5 +64,10 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
 
             this.AddOutputPath(this.outputBlob.Name);
         }
+
+        public override void AddFilePath(string filePath)
+        {
+            // No file mapping is done in azure blob writer, so ignore.
+        }
     }
 }

--- a/Core.Collectors/IO/IRecordWriter.cs
+++ b/Core.Collectors/IO/IRecordWriter.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
         Task WriteLineAsync(string content);
         Task WriteRecordAsync(JObject record, RecordContext context);
         Task NewOutputAsync(string outputSuffix, int fileIndex = 0);
+        void AddFilePath(string filePath);
     }
 
     public enum RecordWriterType

--- a/Core.Collectors/IO/RecordWriterCore.cs
+++ b/Core.Collectors/IO/RecordWriterCore.cs
@@ -65,6 +65,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
         protected abstract Task InitializeInternalAsync();
         protected abstract Task<StreamWriter> NewStreamWriterAsync(string suffix);
         protected abstract Task NotifyCurrentOutputAsync();
+        public abstract void AddFilePath(string filePath);
 
         public IEnumerable<string> OutputPaths => this.outputPaths;
 

--- a/Core.Collectors/IO/SplitAzureBlobRecordWriter.cs
+++ b/Core.Collectors/IO/SplitAzureBlobRecordWriter.cs
@@ -80,6 +80,11 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             this.outputPathPrefix = outputPathPrefix;
         }
 
+        public void AddFilePath(string filePath)
+        {
+            // No file mapping is done in split azure blob writer, so ignore.
+        }
+
         protected string OutputPathPrefix => this.GetOutputPathPrefix(this.functionContext.FunctionStartDate);
 
         protected string GetOutputPathPrefix(DateTime dateTimeUtc)


### PR DESCRIPTION
Not having a map from blob files to ADLS is making some of the debugging more difficult. This change introduces that mapping.