### PR TITLE
Introduce new OpenTelemetryTelemetryClient and AggregateTelemetryClient

### DIFF
--- a/Core.Collectors/Web/HttpClientWrapper.cs
+++ b/Core.Collectors/Web/HttpClientWrapper.cs
@@ -50,11 +50,6 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
 
         private async Task<HttpResponseMessage> MakeRequestAsync(string requestUrl, HttpMethod method, string requestBody, IAuthentication authentication, ProductInfoHeaderValue productInfoHeaderValue, string eTag)
         {
-            using Activity requestTrace = OpenTelemetryTracer.GetActivity(OpenTelemetryTrace.Request).Start();
-            requestTrace.AddTag("Url", requestUrl);
-            requestTrace.AddTag("Method", method);
-            requestTrace.AddTag("AuthenticationType", authentication.GetType().ToString());
-
             HttpRequestMessage request = new HttpRequestMessage
             {
                 Method = method,
@@ -81,24 +76,8 @@ namespace Microsoft.CloudMine.Core.Collectors.Web
                 request.Headers.IfNoneMatch.Add(new EntityTagHeaderValue(eTag));
             }
 
-            try
-            {
-                HttpResponseMessage result = await this.httpClient.SendAsync(request).ConfigureAwait(false);
-                requestTrace.AddTag("StatusCode", result.StatusCode);
-                requestTrace.AddTag("Error", false);
-                return result;
-            }
-            catch (Exception e)
-            {
-                requestTrace.AddTag("ExceptionType", e.GetType().ToString());
-                requestTrace.AddTag("ExceptionMessage", e.Message);
-                requestTrace.AddTag("Error", true);
-                throw;
-            }
-            finally
-            {
-                requestTrace.AddTag("Duration", requestTrace.Duration.TotalMilliseconds.ToString());
-            }
+            HttpResponseMessage result = await this.httpClient.SendAsync(request).ConfigureAwait(false);
+            return result;
         }
     }
 }

--- a/Core.Telemetry/AggregateTelemetryClient.cs
+++ b/Core.Telemetry/AggregateTelemetryClient.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace Microsoft.CloudMine.Core.Telemetry
+{
+    public class AggregateTelemetryClient : ITelemetryClient
+    {
+
+        private readonly IEnumerable<ITelemetryClient> telemetryClients;
+
+        public AggregateTelemetryClient(IEnumerable<ITelemetryClient> telemetryClients)
+        {
+            this.telemetryClients = telemetryClients;
+        }
+
+        public void LogCritical(string message, IDictionary<string, string> properties = null)
+        {
+            foreach (ITelemetryClient telemetryClient in this.telemetryClients)
+            {
+                telemetryClient.LogCritical(message, properties);
+            }
+        }
+
+        public void LogInformation(string message, IDictionary<string, string> properties = null)
+        {
+            foreach (ITelemetryClient telemetryClient in this.telemetryClients)
+            {
+                telemetryClient.LogInformation(message, properties);
+            }
+        }
+
+        public void LogWarning(string message, IDictionary<string, string> properties = null)
+        {
+            foreach (ITelemetryClient telemetryClient in this.telemetryClients)
+            {
+                telemetryClient.LogWarning(message, properties);
+            }
+        }
+
+        public void TrackEvent(string eventName, IDictionary<string, string> properties = null)
+        {
+            foreach (ITelemetryClient telemetryClient in this.telemetryClients)
+            {
+                telemetryClient.TrackEvent(eventName, properties);
+            }
+        }
+
+        public void TrackException(Exception exception, string message = null, IDictionary<string, string> properties = null)
+        {
+            foreach (ITelemetryClient telemetryClient in this.telemetryClients)
+            {
+                telemetryClient.TrackException(exception, message, properties);
+            }
+        }
+
+        public void TrackRequest(string identity, string apiName, string requestUrl, string eTag, TimeSpan duration, HttpResponseMessage responseMessage)
+        {
+            foreach (ITelemetryClient telemetryClient in this.telemetryClients)
+            {
+                telemetryClient.TrackRequest(identity, apiName, requestUrl, eTag, duration, responseMessage);
+            }
+        }
+
+        public void TrackRequest(string identity, string apiName, string requestUrl, string requestBody, string eTag, TimeSpan duration, HttpResponseMessage responseMessage)
+        {
+            foreach (ITelemetryClient telemetryClient in this.telemetryClients)
+            {
+                telemetryClient.TrackRequest(identity, apiName, requestUrl, requestBody, eTag, duration, responseMessage);
+            }
+        }
+    }
+}

--- a/Core.Telemetry/ApplicationInsightsTelemetryClient.cs
+++ b/Core.Telemetry/ApplicationInsightsTelemetryClient.cs
@@ -15,13 +15,17 @@ namespace Microsoft.CloudMine.Core.Telemetry
     {
         private readonly TelemetryClient telemetryClient;
         private readonly string sessionId;
-        protected readonly ILogger logger;
 
         public ApplicationInsightsTelemetryClient(TelemetryClient telemetryClient, string sessionId, ILogger logger)
+            :this(telemetryClient, sessionId)
+        {
+            // TODO: Luke G - Remove this constructor, left in temporarilly to make change for non-breaking
+        }
+
+        public ApplicationInsightsTelemetryClient(TelemetryClient telemetryClient, string sessionId)
         {
             this.telemetryClient = telemetryClient;
             this.sessionId = sessionId;
-            this.logger = logger;
         }
 
         public void LogInformation(string message, IDictionary<string, string> additionalProperties = null)
@@ -37,7 +41,6 @@ namespace Microsoft.CloudMine.Core.Telemetry
             properties.Add("Message", message);
 
             this.telemetryClient.TrackTrace(message, SeverityLevel.Information, properties);
-            this.logger.LogInformation(message);
         }
 
         public void LogCritical(string message, IDictionary<string, string> additionalProperties = null)
@@ -53,7 +56,6 @@ namespace Microsoft.CloudMine.Core.Telemetry
             properties.Add("Message", message);
 
             this.telemetryClient.TrackTrace(message, SeverityLevel.Critical, properties);
-            this.logger.LogCritical(message);
         }
 
         public void TrackException(Exception exception, string message = null, IDictionary<string, string> additionalProperties = null)
@@ -69,7 +71,6 @@ namespace Microsoft.CloudMine.Core.Telemetry
             properties.Add("Message", message);
 
             this.telemetryClient.TrackException(exception, properties);
-            this.logger.LogError(exception, "Exception", string.Join(Environment.NewLine, properties));
         }
 
         public void LogWarning(string message, IDictionary<string, string> additionalProperties = null)
@@ -79,7 +80,7 @@ namespace Microsoft.CloudMine.Core.Telemetry
             {
                 foreach (KeyValuePair<string, string> property in additionalProperties)
                 {
-                    if ( properties.ContainsKey(property.Key) )
+                    if (properties.ContainsKey(property.Key))
                     {
                         properties[property.Key] = property.Value;
                     }
@@ -91,7 +92,6 @@ namespace Microsoft.CloudMine.Core.Telemetry
             }
 
             this.telemetryClient.TrackTrace(message, SeverityLevel.Warning, properties);
-            this.logger.LogWarning(message, string.Join(Environment.NewLine, properties));
         }
 
         public void TrackEvent(string eventName, IDictionary<string, string> additionalProperties = null)
@@ -113,7 +113,6 @@ namespace Microsoft.CloudMine.Core.Telemetry
             }
 
             this.telemetryClient.TrackEvent(eventName, properties);
-            this.logger.LogInformation("Custom Event {EventName} : {Properties}", eventName, JsonConvert.SerializeObject(properties));
         }
 
         public virtual void TrackRequest(string identity, string apiName, string requestUrl, string eTag, TimeSpan duration, HttpResponseMessage responseMessage)

--- a/Core.Telemetry/ApplicationInsightsTelemetryClient.cs
+++ b/Core.Telemetry/ApplicationInsightsTelemetryClient.cs
@@ -80,14 +80,7 @@ namespace Microsoft.CloudMine.Core.Telemetry
             {
                 foreach (KeyValuePair<string, string> property in additionalProperties)
                 {
-                    if (properties.ContainsKey(property.Key))
-                    {
-                        properties[property.Key] = property.Value;
-                    }
-                    else
-                    {
-                        properties.Add(property.Key, property.Value);
-                    }
+                    properties[property.Key] = property.Value;
                 }
             }
 
@@ -101,14 +94,7 @@ namespace Microsoft.CloudMine.Core.Telemetry
             {
                 foreach (KeyValuePair<string, string> property in additionalProperties)
                 {
-                    if (properties.ContainsKey(property.Key))
-                    {
-                        properties[property.Key] = property.Value;
-                    }
-                    else
-                    {
-                        properties.Add(property.Key, property.Value);
-                    }
+                    properties[property.Key] = property.Value;
                 }
             }
 

--- a/Core.Telemetry/OpenTelemetryTelemetryClient.cs
+++ b/Core.Telemetry/OpenTelemetryTelemetryClient.cs
@@ -1,0 +1,168 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+
+namespace Microsoft.CloudMine.Core.Telemetry
+{
+    public class OpenTelemetryTelemetryClient : ITelemetryClient
+    {
+        private readonly string sessionId;
+
+        public OpenTelemetryTelemetryClient(string sessionId)
+        {
+            this.sessionId = sessionId;
+        }
+
+        public void LogInformation(string message, IDictionary<string, string> additionalProperties = null)
+        {
+            using Activity trace = OpenTelemetryTracer.GetActivity(message).Start();
+            trace.AddTag("Severity", "Information");
+
+            Dictionary<string, string> properties = this.GetContextProperties();
+
+            if (additionalProperties != null)
+            {
+                foreach (KeyValuePair<string, string> property in additionalProperties)
+                {
+                    properties.Add(property.Key, property.Value);
+                }
+            }
+
+            foreach (string key in properties.Keys)
+            {
+                trace.AddTag(key, properties[key]);
+            }
+        }
+
+
+        public void LogCritical(string message, IDictionary<string, string> additionalProperties = null)
+        {
+            using Activity trace = OpenTelemetryTracer.GetActivity(message).Start();
+            trace.AddTag("Severity", "Critical");
+
+            Dictionary<string, string> properties = this.GetContextProperties();
+            if (additionalProperties != null)
+            {
+                foreach (KeyValuePair<string, string> property in additionalProperties)
+                {
+                    properties.Add(property.Key, property.Value);
+                }
+            }
+
+            foreach (string key in properties.Keys)
+            {
+                trace.AddTag(key, properties[key]);
+            }
+        }
+
+        public void TrackException(Exception exception, string message = null, IDictionary<string, string> additionalProperties = null)
+        {
+            using Activity trace = OpenTelemetryTracer.GetActivity("Exception").Start();
+            trace.AddTag("ExceptionMessage", message);
+            trace.AddTag("ExceptionType", exception.GetType().Name);
+
+            if (exception.StackTrace != null)
+            {
+                trace.AddTag("ParsedStack", exception.StackTrace);
+            }
+
+            Dictionary<string, string> properties = this.GetContextProperties();
+            if (additionalProperties != null)
+            {
+                foreach (KeyValuePair<string, string> property in additionalProperties)
+                {
+                    properties.Add(property.Key, property.Value);
+                }
+            }
+
+            foreach (string key in properties.Keys)
+            {
+                trace.AddTag(key, properties[key]);
+            }
+        }
+
+        public void LogWarning(string message, IDictionary<string, string> additionalProperties = null)
+        {
+            using Activity trace = OpenTelemetryTracer.GetActivity(message).Start();
+            trace.AddTag("Severity", "Warning");
+
+            Dictionary<string, string> properties = this.GetContextProperties();
+            if (additionalProperties != null)
+            {
+                foreach (KeyValuePair<string, string> property in additionalProperties)
+                {
+                    properties.Add(property.Key, property.Value);
+                }
+            }
+
+            foreach (string key in properties.Keys)
+            {
+                trace.AddTag(key, properties[key]);
+            }
+        }
+
+        public void TrackEvent(string eventName, IDictionary<string, string> additionalProperties = null)
+        {
+            using Activity trace = OpenTelemetryTracer.GetActivity(eventName).Start();
+            trace.AddTag("Severity", "Event");
+
+            Dictionary<string, string> properties = this.GetContextProperties();
+            if (additionalProperties != null)
+            {
+                foreach (KeyValuePair<string, string> property in additionalProperties)
+                {
+                    properties.Add(property.Key, property.Value);
+                }
+            }
+
+            foreach (string key in properties.Keys)
+            {
+                trace.AddTag(key, properties[key]);
+            }
+        }
+
+        public virtual void TrackRequest(string identity, string apiName, string requestUrl, string eTag, TimeSpan duration, HttpResponseMessage responseMessage)
+        {
+            this.TrackRequest(identity, apiName, requestUrl, requestBody: string.Empty, eTag, duration, responseMessage);
+        }
+
+        public void TrackRequest(string identity, string apiName, string requestUrl, string requestBody, string eTag, TimeSpan duration, HttpResponseMessage responseMessage)
+        {
+            using Activity trace = OpenTelemetryTracer.GetActivity("Request").Start();
+
+            Dictionary<string, string> properties = this.GetContextProperties();
+
+            foreach (string key in properties.Keys)
+            {
+                trace.AddTag(key, properties[key]);
+            }
+
+            string identityToTrack = identity;
+            bool guidIdentity = Guid.TryParse(identityToTrack, out Guid _);
+            if (guidIdentity)
+            {
+                identityToTrack = identityToTrack.Substring(0, 4); // For security reasons, if the identity is a GUID, only capture the first 4 characters in the telemetry.
+            }
+
+            trace.AddTag("ApiName", apiName);
+            trace.AddTag("Url", requestUrl);
+            trace.AddTag("Duration", duration);
+            trace.AddTag("ResultCode", responseMessage.StatusCode.ToString());
+            trace.AddTag("RequestBody", requestBody);
+            trace.AddTag("ETag", eTag);
+            trace.AddTag("Identity", identityToTrack);
+        }
+
+        private Dictionary<string, string> GetContextProperties()
+        {
+            return new Dictionary<string, string>()
+                {
+                    { "SessionId", this.sessionId },
+                };
+        }
+    }
+}

--- a/Core.Telemetry/OpenTelemetryTelemetryClient.cs
+++ b/Core.Telemetry/OpenTelemetryTelemetryClient.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CloudMine.Core.Telemetry
             }
         }
 
-
         public void LogCritical(string message, IDictionary<string, string> additionalProperties = null)
         {
             using Activity trace = OpenTelemetryTracer.GetActivity(message).Start();

--- a/Core.Telemetry/OpenTelemetryTracer.cs
+++ b/Core.Telemetry/OpenTelemetryTracer.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CloudMine.Core.Telemetry
         public static Activity GetActivity(string name)
         {
             return ActivitySource.CreateActivity(name, ActivityKind.Internal).AddDefaultTags();
-
         }
 
         public static void Dispose()

--- a/Core.Telemetry/OpenTelemetryTracer.cs
+++ b/Core.Telemetry/OpenTelemetryTracer.cs
@@ -18,6 +18,12 @@ namespace Microsoft.CloudMine.Core.Telemetry
             return ActivitySource.CreateActivity(trace.Name, ActivityKind.Internal).AddDefaultTags();
         }
 
+        public static Activity GetActivity(string name)
+        {
+            return ActivitySource.CreateActivity(name, ActivityKind.Internal).AddDefaultTags();
+
+        }
+
         public static void Dispose()
         {
             TracerProvider.Dispose();


### PR DESCRIPTION
# Changes

## New Classes
### OpenTelemetryTelemetryClient
implements ITelemetryClient and emits OpenTelemetry events as Spans.

### AggregateTelemetryClient
implements ITelemetryClient, constructed of multiple ITelemetryClient objects and emits telemetry to each. This will be used to Aggregate ApplicationInsight and OpenTelemetry telemetry clients during migration to Genva.

## Modifications

### HttpClientWrapper
remove trace from http requests as these will be tracked through telemetry.

### ApplicationInsightsTelemetryClient
remove logging from telemetry client, this behavior is redundant with modern telemetry.

### OpenTelemetryTracer
add `GetActivity(string name)` to allow OpenTelemetryTelemetryClient to create custom named Spans.  