### PR TITLE
Added SiteName to default telemetry tags

### DIFF
--- a/Core.Telemetry/OpenTelemetryHelpers.cs
+++ b/Core.Telemetry/OpenTelemetryHelpers.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 
@@ -15,6 +16,7 @@ namespace Microsoft.CloudMine.Core.Telemetry
         public static readonly string AppEnvironment;
         public static readonly string Deployment;
         public static readonly string Region;
+        public static readonly string SiteName;
         public static readonly string OpenTelemetryExporter;
         
         static OpenTelemetryHelpers()
@@ -23,10 +25,11 @@ namespace Microsoft.CloudMine.Core.Telemetry
             AppEnvironment = Environment.GetEnvironmentVariable("Environment") ?? "*";
             Deployment = Environment.GetEnvironmentVariable("Deployment") ?? "*";
             Region = Environment.GetEnvironmentVariable("Region") ?? "*";
+            SiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") ?? "*";
             Product = Environment.GetEnvironmentVariable("Product");
             Service = Environment.GetEnvironmentVariable("Service");
 
-            if( Product == null || Service == null )
+            if ( Product == null || Service == null )
             {
                 OpenTelemetryExporter = "*";
                 Product = "*";
@@ -41,6 +44,7 @@ namespace Microsoft.CloudMine.Core.Telemetry
             activity.AddTag("Environment", AppEnvironment);
             activity.AddTag("Deployment", Deployment);
             activity.AddTag("Region", Region);
+            activity.AddTag("SiteName",SiteName);
             activity.AddTag("Depth", GetActivityDepth() + 1);
             return activity;
         }
@@ -68,6 +72,7 @@ namespace Microsoft.CloudMine.Core.Telemetry
             tags.Add("Environment", AppEnvironment);
             tags.Add("Deployment", Deployment);
             tags.Add("Region", Region);
+            tags.Add("SiteName", SiteName);
             counter.Add(value, tags);
         }
     }

--- a/Core.Telemetry/OpenTelemetryHelpers.cs
+++ b/Core.Telemetry/OpenTelemetryHelpers.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 


### PR DESCRIPTION
Addtional default tag on metrics and traces `SiteName` which allows for improved dashboard integration.