### PR TITLE
Capture ResponseCode in RateLimiter cache.

### DIFF
--- a/Core.Collectors/Cache/RateLimitTableEntity.cs
+++ b/Core.Collectors/Cache/RateLimitTableEntity.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net;
 
 namespace Microsoft.CloudMine.Core.Collectors.Cache
 {
@@ -17,6 +18,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Cache
         public DateTime? RateLimitReset { get; set; }
         public DateTime? RetryAfter { get; set; }
         public string Resource { get; set; }
+        public string StatusCode { get; set; }
 
         // Used for serialization.
         public RateLimitTableEntity()
@@ -25,17 +27,17 @@ namespace Microsoft.CloudMine.Core.Collectors.Cache
 
         // Used only to retrieve (lookup) entries.
         public RateLimitTableEntity(string identity, string organizationId, string organizationName)
-            : this(identity, organizationId, organizationName, rateLimitLimit: long.MinValue, rateLimitRemaining: long.MinValue, rateLimitReset: null, retryAfter: null, resource: null)
+            : this(identity, organizationId, organizationName, rateLimitLimit: long.MinValue, rateLimitRemaining: long.MinValue, rateLimitReset: null, retryAfter: null, resource: null, statusCode: HttpStatusCode.OK.ToString())
         {
         }
 
         // Used for backwards-compatibility purposes.
         public RateLimitTableEntity(string identity, string organizationId, string organizationName, long rateLimitLimit, long rateLimitRemaining, DateTime? rateLimitReset, DateTime? retryAfter)
-            : this(identity, organizationId, organizationName, rateLimitLimit, rateLimitRemaining, rateLimitReset, retryAfter, resource: null)
+            : this(identity, organizationId, organizationName, rateLimitLimit, rateLimitRemaining, rateLimitReset, retryAfter, resource: null, statusCode: HttpStatusCode.OK.ToString())
         {
         }
 
-        public RateLimitTableEntity(string identity, string organizationId, string organizationName, long rateLimitLimit, long rateLimitRemaining, DateTime? rateLimitReset, DateTime? retryAfter, string resource)
+        public RateLimitTableEntity(string identity, string organizationId, string organizationName, long rateLimitLimit, long rateLimitRemaining, DateTime? rateLimitReset, DateTime? retryAfter, string resource, string statusCode)
         {
             this.PartitionKey = identity;
             this.RowKey = organizationId;
@@ -48,6 +50,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Cache
             this.RateLimitReset = rateLimitReset;
             this.RetryAfter = retryAfter;
             this.Resource = resource;
+            this.StatusCode = statusCode;
 
             this.AddContext("Identity", this.Identity);
             this.AddContext("OrganizationIdString", this.OrganizationIdString);
@@ -57,6 +60,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Cache
             this.AddContext("RateLimitReset", $"{this.RateLimitReset:O}");
             this.AddContext("RetryAfter", $"{this.RetryAfter:O}");
             this.AddContext("Resource", this.Resource);
+            this.AddContext("StatusCode", this.StatusCode);
         }
     }
 }


### PR DESCRIPTION
This is useful to improve Azure DevOps rate limiter. Also fix the way internal caching for rate limiting details are done.