### PR TITLE
Fix ROS timestamp bug

### DIFF
--- a/Core.Collectors/IO/AdlsBulkRecordWriter.cs
+++ b/Core.Collectors/IO/AdlsBulkRecordWriter.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
             Stopwatch uploadTimer = Stopwatch.StartNew();
             string adlsDirectory = $"{adlsConfig.AdlsRoot}/{adlsConfig.Version}";
 
-            TransferStatus status = adlsConfig.AdlsClient.BulkUpload(this.localRoot, adlsDirectory);
+            TransferStatus status = adlsConfig.AdlsClient.BulkUpload(this.localRoot, adlsDirectory, shouldOverwrite: IfExists.Fail);
             bool retried = false;
             if (status.EntriesFailed.Count != 0)
             {

--- a/Core.Collectors/IO/RecordWriterCore.cs
+++ b/Core.Collectors/IO/RecordWriterCore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using Microsoft.CloudMine.Core.Collectors.Context;
@@ -81,7 +81,7 @@ namespace Microsoft.CloudMine.Core.Collectors.IO
 
         protected string OutputPathPrefix => this.GetOutputPathPrefix(this.functionContext.FunctionStartDate);
 
-        protected string GetOutputPathPrefix(DateTime dateTimeUtc)
+        protected virtual string GetOutputPathPrefix(DateTime dateTimeUtc)
         {
             return $"{this.outputPathPrefix}/{dateTimeUtc:yyyy/MM/dd/HH.mm.ss}_{this.identifier}_{this.functionContext.SessionId}";
         }


### PR DESCRIPTION
When ROS (ADLS Bulk upload writer) starts uploads very close to each other (within the same second), the final ADLS path becomes the same as the previous upload and therefore the data gets overwritten. This results in data loss.

This change appends a serial number (upload index) at the end of the file names to ensure that the file paths are always unique for a given ADLS Bulk Record Writer (ROS) instance.